### PR TITLE
make AWindow.SurfaceCallback interface public

### DIFF
--- a/libvlc/src/org/videolan/libvlc/AWindow.java
+++ b/libvlc/src/org/videolan/libvlc/AWindow.java
@@ -44,7 +44,7 @@ public class AWindow implements IVLCVout {
     private static final int ID_SUBTITLES = 1;
     private static final int ID_MAX = 2;
 
-    interface SurfaceCallback {
+    public interface SurfaceCallback {
         @MainThread
         void onSurfacesCreated(AWindow vout);
         @MainThread


### PR DESCRIPTION
This interface is part of AWindow which is the standard JNI object to interact with the public libvlc API. So I think it should be public just like AWindow is. 

And also, I need to access it for my bindings :D.