### PR TITLE
Avoid remeasurement of view hierarchy every 1 sec

### DIFF
--- a/vlc-android/res/layout/audio_player.xml
+++ b/vlc-android/res/layout/audio_player.xml
@@ -138,8 +138,8 @@
 
             <TextView
                 android:id="@+id/header_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="80dp"
+                android:layout_height="30dp"
                 android:layout_gravity="center|left"
                 android:layout_marginLeft="@dimen/default_margin"
                 android:layout_marginRight="@dimen/default_margin"
@@ -214,8 +214,8 @@
 
         <TextView
             android:id="@+id/time"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="50dp"
+            android:layout_height="20dp"
             android:layout_gravity="center|left"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/timeline"
@@ -245,8 +245,8 @@
 
         <TextView
             android:id="@+id/length"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="50dp"
+            android:layout_height="20dp"
             android:layout_gravity="center|right"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@+id/timeline"


### PR DESCRIPTION
time, length and header_time textboxes are updated every 1 second while playing audio; wrap_content width and height of these boxes cause unnecessary remeasurement of the entire view hierarchy. Changing them to have fixed width and height avoids such remeasurement.