### PR TITLE
Improve SubtitleDownloaderDialog styles

### DIFF
--- a/vlc-android/res/layout/subtitle_download_fragment.xml
+++ b/vlc-android/res/layout/subtitle_download_fragment.xml
@@ -143,7 +143,7 @@
         <TextView
             android:id="@+id/message"
             android:layout_width="0dp"
-            android:layout_height="16dp"
+            android:layout_height="20dp"
             android:text="@{viewmodel.observableMessage}"
             android:textColor="@color/red"
             android:gravity="center_horizontal"

--- a/vlc-android/res/layout/subtitle_download_fragment.xml
+++ b/vlc-android/res/layout/subtitle_download_fragment.xml
@@ -155,12 +155,12 @@
             app:layout_constraintStart_toStartOf="@+id/left_vertical_guideline"
             app:layout_goneMarginTop="40dp" />
 
-        <Spinner
+        <org.videolan.vlc.gui.MultiSelectionSpinner
             android:id="@+id/language_list_spinner"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
-            android:entries="@array/language_entries"
+            android:focusable="true"
             app:layout_constraintEnd_toStartOf="@+id/right_vertical_guideline"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintTop_toTopOf="@+id/top_horizontal_guideline" />

--- a/vlc-android/res/layout/subtitle_download_fragment.xml
+++ b/vlc-android/res/layout/subtitle_download_fragment.xml
@@ -110,8 +110,8 @@
             app:refreshing="@{viewmodel.isApiLoading}"
             app:onRefreshListener="@{()-> viewmodel.onRefresh()}"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/right_vertical_guideline"
-            app:layout_constraintStart_toStartOf="@+id/left_vertical_guideline"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/barrier" >
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/subtitle_list"

--- a/vlc-android/res/layout/subtitle_download_item.xml
+++ b/vlc-android/res/layout/subtitle_download_item.xml
@@ -12,6 +12,9 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:background="?android:attr/selectableItemBackground"
         android:minHeight="50dp"
         android:focusable="true">
 

--- a/vlc-android/res/layout/subtitle_history_fragment.xml
+++ b/vlc-android/res/layout/subtitle_history_fragment.xml
@@ -11,8 +11,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginBottom="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:focusable="true"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/vlc-android/res/values/arrays.xml
+++ b/vlc-android/res/values/arrays.xml
@@ -11,7 +11,6 @@
     </string-array>
 
     <string-array name="language_entries">
-        <item>All</item>
         <item>Albanian</item>
         <item>Arabic</item>
         <item>Armenian</item>
@@ -80,7 +79,6 @@
     </string-array>
 
     <string-array name="language_values">
-        <item></item>
         <item>alb</item>
         <item>ara</item>
         <item>arm</item>

--- a/vlc-android/res/values/strings.xml
+++ b/vlc-android/res/values/strings.xml
@@ -647,8 +647,8 @@
     <string name="subtitle_search_episode_hint">Episode</string>
     <string name="subtitle_search_season_hint">Season</string>
     <string name="language_to_download">Language</string>
-    <string name="delete_the_selected">Delete the selected</string>
-    <string name="download_the_selected">Download the selected</string>
+    <string name="delete_the_selected">Delete selection</string>
+    <string name="download_the_selected">Download selection</string>
     <string name="next">Next</string>
     <string name="download">Download</string>
 </resources>

--- a/vlc-android/res/values/strings.xml
+++ b/vlc-android/res/values/strings.xml
@@ -647,6 +647,8 @@
     <string name="subtitle_search_episode_hint">Episode</string>
     <string name="subtitle_search_season_hint">Season</string>
     <string name="language_to_download">Language</string>
+    <string name="delete_the_selected">Delete the selected</string>
+    <string name="download_the_selected">Download the selected</string>
     <string name="next">Next</string>
     <string name="download">Download</string>
 </resources>

--- a/vlc-android/src/org/videolan/vlc/gui/MultiSelectionSpinner.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/MultiSelectionSpinner.kt
@@ -83,10 +83,9 @@ class MultiSelectionSpinner : AppCompatSpinner, OnMultiChoiceClickListener, Dial
             if (it >= 0 && it < selection.size) selection[it] = true
             else throw IllegalArgumentException("Index $it is out of bounds.")
         }
-
         adapter.clear()
         adapter.add(buildSelectedItemString())
-        listener?.onItemSelect(this.selectedIndices)
+        listener?.onItemSelect(selectedIndices)
     }
 
     private fun buildSelectedItemString(): String {
@@ -94,7 +93,7 @@ class MultiSelectionSpinner : AppCompatSpinner, OnMultiChoiceClickListener, Dial
 
         val selectedItems = items.filterIndexed { index, _ -> selection[index] }
 
-        if (selectedItems.isEmpty()) sb.append("All")
+        if (selectedItems.isEmpty() || selectedItems.size == items.size) sb.append("All")
         else selectedItems.forEachIndexed { index, s ->
             if (index > 0) sb.append(',')
             sb.append(s)

--- a/vlc-android/src/org/videolan/vlc/gui/MultiSelectionSpinner.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/MultiSelectionSpinner.kt
@@ -1,0 +1,113 @@
+package org.videolan.vlc.gui
+
+import android.app.AlertDialog
+import android.content.Context
+import android.content.DialogInterface
+import android.content.DialogInterface.OnMultiChoiceClickListener
+import android.util.AttributeSet
+import android.widget.ArrayAdapter
+import android.widget.SpinnerAdapter
+import androidx.appcompat.widget.AppCompatSpinner
+
+
+class MultiSelectionSpinner : AppCompatSpinner, OnMultiChoiceClickListener, DialogInterface.OnDismissListener{
+
+    private var items = mutableListOf<String>()
+    private var selection = mutableListOf<Boolean>()
+    private var adapter: ArrayAdapter<String>
+    private var listener: org.videolan.vlc.gui.OnItemSelectListener? = null
+
+    val selectedIndices: List<Int>
+        get() {
+            return selection.mapIndexed { index, b -> Pair(index, b)}.filter { it.second }.map { it.first }
+        }
+
+    constructor(context: Context) : super(context) {
+        adapter = ArrayAdapter(context, android.R.layout.simple_spinner_item)
+        super.setAdapter(adapter)
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        adapter = ArrayAdapter(context, android.R.layout.simple_spinner_item)
+        super.setAdapter(adapter)
+    }
+
+    override fun onClick(dialog: DialogInterface, index: Int, isChecked: Boolean) {
+        if (index < selection.size) {
+            selection[index] = isChecked
+
+            adapter.clear()
+            adapter.add(buildSelectedItemString())
+        } else {
+            throw IllegalArgumentException(
+                    "Argument 'index' is out of bounds.")
+        }
+    }
+
+    override fun performClick(): Boolean {
+        val builder = AlertDialog.Builder(context)
+        builder.setOnDismissListener(this)
+        builder.setMultiChoiceItems(items.toTypedArray(), selection.toBooleanArray(), this).show()
+        return true
+    }
+
+    override fun onDismiss(dialog: DialogInterface?) {
+        listener?.onItemSelect(selectedIndices)
+    }
+
+    override fun setAdapter(adapter: SpinnerAdapter) {
+        throw RuntimeException(
+                "setAdapter is not supported by MultiSelectSpinner. Use setItems instead")
+    }
+
+    fun setItems(items: List<String>) {
+        this.items = items.toMutableList()
+        adapter.clear()
+        adapter.add(items[0])
+        selection.addAll(items.map{false})
+    }
+
+    override fun setSelection(index: Int) {
+        selection = selection.map { false }.toMutableList()
+
+        if (index >= 0 && index < selection.size) selection[index] = true
+        else throw IllegalArgumentException("Index $index is out of bounds.")
+        adapter.clear()
+        adapter.add(buildSelectedItemString())
+        listener?.onItemSelect(selectedIndices)
+    }
+
+    fun setSelection(selectedIndices: List<Int>) {
+        selection = selection.map { false }.toMutableList()
+        selectedIndices.forEach {
+            if (it >= 0 && it < selection.size) selection[it] = true
+            else throw IllegalArgumentException("Index $it is out of bounds.")
+        }
+
+        adapter.clear()
+        adapter.add(buildSelectedItemString())
+        listener?.onItemSelect(this.selectedIndices)
+    }
+
+    private fun buildSelectedItemString(): String {
+        val sb = StringBuilder()
+
+        val selectedItems = items.filterIndexed { index, _ -> selection[index] }
+
+        if (selectedItems.isEmpty()) sb.append("All")
+        else selectedItems.forEachIndexed { index, s ->
+            if (index > 0) sb.append(',')
+            sb.append(s)
+        }
+        return sb.toString()
+    }
+
+    fun setOnItemsSelectListener(l: org.videolan.vlc.gui.OnItemSelectListener) {
+        listener = l
+    }
+}
+
+interface OnItemSelectListener {
+    fun onItemSelect(selectedItems: List<Int>)
+}
+

--- a/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
@@ -6,9 +6,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.AdapterView
 import org.videolan.vlc.R
 import org.videolan.vlc.databinding.SubtitleDownloadFragmentBinding
+import org.videolan.vlc.gui.OnItemSelectListener
 import org.videolan.vlc.gui.helpers.UiTools
 import org.videolan.vlc.util.AndroidDevices
 import org.videolan.vlc.viewmodels.SubtitlesModel
@@ -49,16 +49,16 @@ class SubtitleDownloadFragment : androidx.fragment.app.Fragment() {
         }
 
         val allValuesOfLanguages = resources.getStringArray(R.array.language_values)
-        binding.languageListSpinner.setSelection(allValuesOfLanguages.indexOf(viewModel.getLastUsedLanguage()))
-        binding.languageListSpinner.onItemSelectedListener = object :AdapterView.OnItemSelectedListener {
-            override fun onNothingSelected(parent: AdapterView<*>?) { }
-
-            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                val selectedLanguage = allValuesOfLanguages[position]
-                viewModel.observableSearchLanguage.set(selectedLanguage)
+        val allEntriesOfLanguages = resources.getStringArray(R.array.language_entries)
+        binding.languageListSpinner.setOnItemsSelectListener(object: OnItemSelectListener {
+            override fun onItemSelect(selectedItems: List<Int>) {
+                val selectedLanguages = selectedItems.map { allValuesOfLanguages[it] }
+                viewModel.observableSearchLanguage.set(selectedLanguages)
             }
+        })
+        binding.languageListSpinner.setItems(allEntriesOfLanguages.toList())
+        binding.languageListSpinner.setSelection(viewModel.getLastUsedLanguage().map { allValuesOfLanguages.indexOf(it) })
 
-        }
         return binding.root
     }
 

--- a/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
@@ -3,21 +3,14 @@ package org.videolan.vlc.gui.dialogs
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
-import kotlinx.coroutines.experimental.channels.actor
-import org.videolan.tools.coroutineScope
 import org.videolan.vlc.R
 import org.videolan.vlc.databinding.SubtitleDownloadFragmentBinding
 import org.videolan.vlc.gui.helpers.UiTools
-import org.videolan.vlc.gui.helpers.UiTools.deleteSubtitleDialog
 import org.videolan.vlc.util.AndroidDevices
-import org.videolan.vlc.util.VLCDownloadManager
 import org.videolan.vlc.viewmodels.SubtitlesModel
 
 class SubtitleDownloadFragment : androidx.fragment.app.Fragment() {
@@ -25,16 +18,6 @@ class SubtitleDownloadFragment : androidx.fragment.app.Fragment() {
     private lateinit var adapter: SubtitlesAdapter
     lateinit var mediaPath: String
 
-    private val listEventActor = coroutineScope.actor<SubtitleItem> {
-        for (subtitleItem in channel)
-            when (subtitleItem.state) {
-                State.NotDownloaded -> {
-                    VLCDownloadManager.download(context!!, subtitleItem)
-                }
-                State.Downloaded -> deleteSubtitleDialog(context,
-                        { _, _ -> viewModel.deleteSubtitle(subtitleItem.mediaPath, subtitleItem.idSubtitle) }, { _, _ -> })
-            }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,7 +34,7 @@ class SubtitleDownloadFragment : androidx.fragment.app.Fragment() {
             //Prevent opening soft keyboard automatically
             binding.constraintLayout.isFocusableInTouchMode = true
 
-        adapter = SubtitlesAdapter(listEventActor)
+        adapter = SubtitlesAdapter((parentFragment as SubtitleDownloaderDialogFragment).listEventActor)
         val recyclerView = binding.subtitleList
         recyclerView.addItemDecoration(androidx.recyclerview.widget.DividerItemDecoration(activity, androidx.recyclerview.widget.DividerItemDecoration.VERTICAL))
         recyclerView.adapter = adapter

--- a/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleDownloadFragment.kt
@@ -52,10 +52,12 @@ class SubtitleDownloadFragment : androidx.fragment.app.Fragment() {
         val allEntriesOfLanguages = resources.getStringArray(R.array.language_entries)
         binding.languageListSpinner.setOnItemsSelectListener(object: OnItemSelectListener {
             override fun onItemSelect(selectedItems: List<Int>) {
-                val selectedLanguages = selectedItems.map { allValuesOfLanguages[it] }
+                val selectedLanguages = if (selectedItems.size == allValuesOfLanguages.size) listOf<String>()
+                else selectedItems.map { allValuesOfLanguages[it] }
                 viewModel.observableSearchLanguage.set(selectedLanguages)
             }
         })
+
         binding.languageListSpinner.setItems(allEntriesOfLanguages.toList())
         binding.languageListSpinner.setSelection(viewModel.getLastUsedLanguage().map { allValuesOfLanguages.indexOf(it) })
 

--- a/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleHistoryFragment.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/dialogs/SubtitleHistoryFragment.kt
@@ -4,31 +4,16 @@ package org.videolan.vlc.gui.dialogs
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.coroutines.experimental.channels.actor
-import org.videolan.tools.coroutineScope
 import org.videolan.vlc.databinding.SubtitleHistoryFragmentBinding
-import org.videolan.vlc.gui.helpers.UiTools.deleteSubtitleDialog
 import org.videolan.vlc.viewmodels.SubtitlesModel
 
 class SubtitleHistoryFragment : androidx.fragment.app.Fragment() {
     private lateinit var viewModel: SubtitlesModel
     private lateinit var adapter: SubtitlesAdapter
     lateinit var mediaPath: String
-
-    private val listEventActor = coroutineScope.actor<SubtitleItem> {
-        for (event in channel)
-            if (event.state == State.Downloaded) {
-                deleteSubtitleDialog(context,
-                        { _, _ -> viewModel.deleteSubtitle(event.mediaPath, event.idSubtitle)
-                        }, { _, _ -> })
-            }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,7 +25,7 @@ class SubtitleHistoryFragment : androidx.fragment.app.Fragment() {
         super.onCreateView(inflater, container, savedInstanceState)
         val binding = SubtitleHistoryFragmentBinding.inflate(inflater, container, false)
 
-        adapter = SubtitlesAdapter(listEventActor)
+        adapter = SubtitlesAdapter((parentFragment as SubtitleDownloaderDialogFragment).listEventActor)
         val recyclerView = binding.subtitleList
         recyclerView.addItemDecoration(androidx.recyclerview.widget.DividerItemDecoration(activity, androidx.recyclerview.widget.DividerItemDecoration.VERTICAL))
         recyclerView.adapter = adapter
@@ -59,6 +44,4 @@ class SubtitleHistoryFragment : androidx.fragment.app.Fragment() {
             return subtitleHistoryFragment
         }
     }
-
-
 }

--- a/vlc-android/src/org/videolan/vlc/repository/OpenSubtitleRepository.kt
+++ b/vlc-android/src/org/videolan/vlc/repository/OpenSubtitleRepository.kt
@@ -49,10 +49,10 @@ class OpenSubtitleRepository(private val openSubtitleService: IOpenSubtitleServi
                 languageId = actualLanguageId) }
     }
 
-    suspend fun queryWithImdbid(imdbId: Int, tag: String?, episode: Int? , season: Int?, languageIds: List<String> ): List<OpenSubtitle> {
+    suspend fun queryWithImdbid(imdbId: Int, tag: String?, episode: Int? , season: Int?, languageIds: List<String>? ): List<OpenSubtitle> {
         val actualEpisode = episode ?: 0
         val actualSeason = season ?: 0
-        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+        val actualLanguageIds = languageIds?.toSet()?.run { if (contains("") || isEmpty()) setOf("") else this } ?: setOf("")
         val actualTag = tag ?: ""
         return actualLanguageIds.flatMap {
             retrofitResponseCall { openSubtitleService.query(
@@ -64,8 +64,8 @@ class OpenSubtitleRepository(private val openSubtitleService: IOpenSubtitleServi
         }
     }
 
-    suspend fun queryWithHash(movieByteSize: Long, movieHash: String, languageIds: List<String>): List<OpenSubtitle> {
-        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+    suspend fun queryWithHash(movieByteSize: Long, movieHash: String, languageIds: List<String>?): List<OpenSubtitle> {
+        val actualLanguageIds = languageIds?.toSet()?.run { if (contains("") || isEmpty()) setOf("") else this } ?: setOf("")
         return actualLanguageIds.flatMap {
             retrofitResponseCall {
                 openSubtitleService.query(
@@ -76,10 +76,10 @@ class OpenSubtitleRepository(private val openSubtitleService: IOpenSubtitleServi
         }
     }
 
-    suspend fun queryWithName(name: String, episode: Int?, season: Int?, languageIds: List<String>): List<OpenSubtitle> {
+    suspend fun queryWithName(name: String, episode: Int?, season: Int?, languageIds: List<String>?): List<OpenSubtitle> {
         val actualEpisode = episode ?: 0
         val actualSeason = season ?: 0
-        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+        val actualLanguageIds = languageIds?.toSet()?.run { if (contains("") || isEmpty()) setOf("") else this } ?: setOf("")
         return actualLanguageIds.flatMap {
             retrofitResponseCall {
                 openSubtitleService.query(

--- a/vlc-android/src/org/videolan/vlc/repository/OpenSubtitleRepository.kt
+++ b/vlc-android/src/org/videolan/vlc/repository/OpenSubtitleRepository.kt
@@ -49,6 +49,48 @@ class OpenSubtitleRepository(private val openSubtitleService: IOpenSubtitleServi
                 languageId = actualLanguageId) }
     }
 
+    suspend fun queryWithImdbid(imdbId: Int, tag: String?, episode: Int? , season: Int?, languageIds: List<String> ): List<OpenSubtitle> {
+        val actualEpisode = episode ?: 0
+        val actualSeason = season ?: 0
+        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+        val actualTag = tag ?: ""
+        return actualLanguageIds.flatMap {
+            retrofitResponseCall { openSubtitleService.query(
+                    imdbId = String.format("%07d", imdbId),
+                    tag = actualTag,
+                    episode = actualEpisode,
+                    season = actualSeason,
+                    languageId = it) }
+        }
+    }
+
+    suspend fun queryWithHash(movieByteSize: Long, movieHash: String, languageIds: List<String>): List<OpenSubtitle> {
+        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+        return actualLanguageIds.flatMap {
+            retrofitResponseCall {
+                openSubtitleService.query(
+                        movieByteSize = movieByteSize.toString(),
+                        movieHash = movieHash,
+                        languageId = it)
+            }
+        }
+    }
+
+    suspend fun queryWithName(name: String, episode: Int?, season: Int?, languageIds: List<String>): List<OpenSubtitle> {
+        val actualEpisode = episode ?: 0
+        val actualSeason = season ?: 0
+        val actualLanguageIds = languageIds.toSet().run { if (contains("")) setOf("") else this }
+        return actualLanguageIds.flatMap {
+            retrofitResponseCall {
+                openSubtitleService.query(
+                        name = name,
+                        episode = actualEpisode,
+                        season = actualSeason,
+                        languageId = it)
+            }
+        }
+    }
+
     companion object { fun getInstance() = OpenSubtitleRepository(OpenSubtitleClient.instance)}
 
     private suspend inline fun <reified T> retrofitResponseCall(crossinline call: () -> Call<T>) : T {

--- a/vlc-android/src/org/videolan/vlc/viewmodels/SubtitlesModel.kt
+++ b/vlc-android/src/org/videolan/vlc/viewmodels/SubtitlesModel.kt
@@ -18,7 +18,7 @@ import org.videolan.vlc.util.Settings
 import java.io.File
 import java.util.*
 
-private const val LAST_USED_LANGUAGE = "last_used_subtitle"
+private const val LAST_USED_LANGUAGES = "last_used_subtitles"
 
 class SubtitlesModel(private val context: Context, private val mediaPath: String): ScopedModel() {
     val observableSearchName = ObservableField<String>()
@@ -156,9 +156,9 @@ class SubtitlesModel(private val context: Context, private val mediaPath: String
         ExternalSubRepository.getInstance(context).deleteSubtitle(mediaPath, idSubtitle)
     }
 
-    fun getLastUsedLanguage() = Settings.getInstance(context).getStringSet(LAST_USED_LANGUAGE, setOf(Locale.getDefault().isO3Language)).map { it.getCompliantLanguageID() }
+    fun getLastUsedLanguage() = Settings.getInstance(context).getStringSet(LAST_USED_LANGUAGES, setOf(Locale.getDefault().isO3Language)).map { it.getCompliantLanguageID() }
 
-    fun saveLastUsedLanguage(lastUsedLanguages: List<String>) = Settings.getInstance(context).edit().putStringSet(LAST_USED_LANGUAGE, lastUsedLanguages.toSet()).apply()
+    fun saveLastUsedLanguage(lastUsedLanguages: List<String>) = Settings.getInstance(context).edit().putStringSet(LAST_USED_LANGUAGES, lastUsedLanguages.toSet()).apply()
 
     class Factory(private val context: Context, private val mediaPath: String): ViewModelProvider.NewInstanceFactory() {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {


### PR DESCRIPTION
In this PR, we will fix subtitle downloader styles.
First commit fixes the message height 
![sub-dl](https://user-images.githubusercontent.com/10830552/47184561-e006bc80-d337-11e8-953d-df2538b08741.jpg)
next commits:
1) Highlight the row of the list when user touches it
2) Show a Toast when user do a long touch ("Download", "Delete" and maybe "Cancel Download") like adv options.
3) Create a custom spinner to select multiple languages
4) Improve dialog sizing in different devices.
