### PR TITLE
Benchmark: disable tips overlay

### DIFF
--- a/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.java
+++ b/vlc-android/src/org/videolan/vlc/gui/video/VideoPlayerActivity.java
@@ -390,7 +390,8 @@ public class VideoPlayerActivity extends AppCompatActivity implements IVLCVout.C
         if (mDisplayManager.isPrimary()) {
             // Orientation
             // Tips
-            if (!BuildConfig.DEBUG && !mIsTv && !mSettings.getBoolean(PREF_TIPS_SHOWN, false)) {
+            if (!BuildConfig.DEBUG && !mIsTv && !mSettings.getBoolean(PREF_TIPS_SHOWN, false)
+                    && !mIsBenchmark) {
                 ((ViewStubCompat) findViewById(R.id.player_overlay_tips)).inflate();
                 mOverlayTips = findViewById(R.id.overlay_tips_layout);
             }


### PR DESCRIPTION
If the benchmark is started from a fresh VLCBenchmark installation, the tips will appear, and could end up on screenshots if the user isn't fast enough, so it is better to disable it in that context.