### PR TITLE
Margins

### DIFF
--- a/vlc-android/res/layout/video_grid.xml
+++ b/vlc-android/res/layout/video_grid.xml
@@ -33,7 +33,7 @@
             android:layout_height="match_parent"
             android:padding="@dimen/half_default_margin"
             android:clipToPadding="false"
-            android:scrollbarStyle="outsideInset"
+            android:scrollbarStyle="outsideOverlay"
             android:numColumns="auto_fit"
             android:fastScrollEnabled="true"
             android:scrollbars="vertical"

--- a/vlc-android/res/layout/video_grid_card.xml
+++ b/vlc-android/res/layout/video_grid_card.xml
@@ -57,10 +57,6 @@
         android:longClickable="true"
         android:onClick="@{holder::onClick}"
         android:onLongClick="@{holder::onLongClick}"
-        android:paddingLeft="@dimen/left_right_1610_margin"
-        android:paddingRight="@dimen/left_right_1610_margin"
-        android:paddingBottom="@dimen/top_bottom_1610_margin"
-        android:paddingTop="@dimen/top_bottom_1610_margin"
         android:background="@{bgColor}" >
 
         <!-- Image loading is handled by org.videolan.vlc.gui.helpers.ImageLoader.loadImage() -->

--- a/vlc-android/src/org/videolan/vlc/gui/helpers/ItemOffsetDecoration.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/helpers/ItemOffsetDecoration.kt
@@ -1,0 +1,25 @@
+package org.videolan.vlc.gui.helpers
+
+import android.content.res.Resources
+import android.graphics.Rect
+import android.view.View
+
+import androidx.annotation.DimenRes
+import androidx.recyclerview.widget.RecyclerView
+
+// Extracted from https://gist.github.com/yqritc/ccca77dc42f2364777e1
+class ItemOffsetDecoration(
+        private val offsetLeftRight: Int,
+        private val offsetTopBottom: Int
+) : RecyclerView.ItemDecoration() {
+
+    constructor(
+            resources: Resources,
+            @DimenRes offsetLeftRightId: Int,
+            @DimenRes offsetTopBottomId: Int
+    ) : this(resources.getDimensionPixelSize(offsetLeftRightId), resources.getDimensionPixelSize(offsetTopBottomId))
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        outRect.set(offsetLeftRight, offsetTopBottom, offsetLeftRight, offsetTopBottom)
+    }
+}

--- a/vlc-android/src/org/videolan/vlc/gui/video/VideoGridFragment.java
+++ b/vlc-android/src/org/videolan/vlc/gui/video/VideoGridFragment.java
@@ -183,7 +183,7 @@ public class VideoGridFragment extends MediaBrowserFragment<VideosModel> impleme
         // Select between grid or list
         if (!listMode) {
             final int thumbnailWidth = res.getDimensionPixelSize(R.dimen.grid_card_thumb_width);
-            final int margin = res.getDimensionPixelSize(R.dimen.default_margin);
+            final int margin = mBinding.videoGrid.getPaddingStart() + mBinding.videoGrid.getPaddingEnd();
             mBinding.videoGrid.setColumnWidth(mBinding.videoGrid.getPerfectColumnWidth(thumbnailWidth, margin));
             mAdapter.setGridCardWidth(mBinding.videoGrid.getColumnWidth());
         }

--- a/vlc-android/src/org/videolan/vlc/gui/video/VideoGridFragment.java
+++ b/vlc-android/src/org/videolan/vlc/gui/video/VideoGridFragment.java
@@ -50,6 +50,7 @@ import org.videolan.vlc.gui.browser.MediaBrowserFragment;
 import org.videolan.vlc.gui.dialogs.ContextSheetKt;
 import org.videolan.vlc.gui.dialogs.CtxActionReceiver;
 import org.videolan.vlc.gui.dialogs.SavePlaylistDialog;
+import org.videolan.vlc.gui.helpers.ItemOffsetDecoration;
 import org.videolan.vlc.gui.helpers.UiTools;
 import org.videolan.vlc.gui.view.SwipeRefreshLayout;
 import org.videolan.vlc.interfaces.IEventsHandler;
@@ -115,6 +116,7 @@ public class VideoGridFragment extends MediaBrowserFragment<VideosModel> impleme
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState){
+        final View view = inflater.inflate(R.layout.video_grid, container,false);
         mBinding = VideoGridBinding.inflate(inflater, container, false);
         return mBinding.getRoot();
     }
@@ -124,6 +126,7 @@ public class VideoGridFragment extends MediaBrowserFragment<VideosModel> impleme
         super.onViewCreated(view, savedInstanceState);
         restart = false;
         final boolean empty = viewModel.getDataset().getValue().isEmpty();
+        mBinding.videoGrid.addItemDecoration(new ItemOffsetDecoration(getResources(), R.dimen.left_right_1610_margin, R.dimen.top_bottom_1610_margin));
         mBinding.loadingFlipper.setVisibility(empty ? View.VISIBLE : View.GONE);
         mBinding.loadingTitle.setVisibility(empty ? View.VISIBLE : View.GONE);
         mBinding.setEmpty(empty);
@@ -184,7 +187,8 @@ public class VideoGridFragment extends MediaBrowserFragment<VideosModel> impleme
         if (!listMode) {
             final int thumbnailWidth = res.getDimensionPixelSize(R.dimen.grid_card_thumb_width);
             final int margin = mBinding.videoGrid.getPaddingStart() + mBinding.videoGrid.getPaddingEnd();
-            mBinding.videoGrid.setColumnWidth(mBinding.videoGrid.getPerfectColumnWidth(thumbnailWidth, margin));
+            final int columnWidth = mBinding.videoGrid.getPerfectColumnWidth(thumbnailWidth, margin) - (res.getDimensionPixelSize(R.dimen.left_right_1610_margin) * 2);
+            mBinding.videoGrid.setColumnWidth(columnWidth);
             mAdapter.setGridCardWidth(mBinding.videoGrid.getColumnWidth());
         }
         mBinding.videoGrid.setNumColumns(listMode ? 1 : -1);


### PR DESCRIPTION
All the commits are related but does different things:
1) Avoid the overlaping between views
2) Left and right margins equal
3) Don't overflow the selection using a `RecyclerView.ItemDecorator`

I can squash them if you prefer.

Before:
![old](https://user-images.githubusercontent.com/721244/51087833-56a92f80-1758-11e9-93ae-91054375b333.png)

After:
![new](https://user-images.githubusercontent.com/721244/51087835-60cb2e00-1758-11e9-9c96-c84968b6e5c8.png)
