### PR TITLE
Add InstantTaskExecutorRule to androidTest

### DIFF
--- a/vlc-android/androidTest/org/videolan/vlc/database/DbTest.kt
+++ b/vlc-android/androidTest/org/videolan/vlc/database/DbTest.kt
@@ -21,6 +21,7 @@
 package org.videolan.vlc.database
 
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.InstrumentationRegistry
 import org.junit.After
@@ -30,6 +31,9 @@ import java.util.concurrent.TimeUnit
 
 
 abstract class DbTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
     @Rule
     @JvmField
     val countingTaskExecutorRule = CountingTaskExecutorRule()

--- a/vlc-android/androidTest/org/videolan/vlc/database/MigrationTest.kt
+++ b/vlc-android/androidTest/org/videolan/vlc/database/MigrationTest.kt
@@ -25,6 +25,7 @@ import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.room.testing.MigrationTestHelper
 import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
 import org.hamcrest.CoreMatchers.`is`
@@ -48,6 +49,9 @@ private const val TEST_DB_NAME = "test-db"
 
 @RunWith(AndroidJUnit4::class)
 class MigrationTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
     @get:Rule
     val migrationTestHelper = MigrationTestHelper(
             InstrumentationRegistry.getInstrumentation(),


### PR DESCRIPTION
Without that the getValue() throws "java.lang.IllegalStateException: Cannot
invoke observeForever on a background thread"