### PR TITLE
Smooth vertical touch 1

### DIFF
--- a/vlc-android/src/org/videolan/vlc/gui/video/VideoTouchDelegate.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/video/VideoTouchDelegate.kt
@@ -37,6 +37,7 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
     private var mInitTouchX = 0f
     private var mTouchY = -1f
     private var mTouchX = -1f
+    private var mVerticalTouchActive = false
 
     private var mLastMove: Long = 0
 
@@ -88,7 +89,7 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
                 }
 
                 val xChanged = if (mTouchX != -1f && mTouchY != -1f) event.rawX - mTouchX else 0f
-                val yChanged = if (xChanged != 0f) event.rawY - mTouchY else 0f
+                val yChanged = if (mTouchX != -1f && mTouchY != -1f) event.rawY - mTouchY else 0f
 
                 // coef is the gradient's move to determine a neutral zone
                 val coef = Math.abs(yChanged / xChanged)
@@ -100,6 +101,7 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
 
                 when (event.action) {
                     MotionEvent.ACTION_DOWN -> {
+                        mVerticalTouchActive = false
                         // Audio
                         mInitTouchY = event.rawY
                         mInitTouchX = event.rawX
@@ -120,7 +122,15 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
                             // No volume/brightness action if coef < 2 or a secondary display is connected
                             //TODO : Volume action when a secondary display is connected
                             if (mTouchAction != TOUCH_SEEK && coef > 2 && player.isOnPrimaryDisplay) {
-                                if (Math.abs(yChanged / screenConfig.yRange) < 0.05) return false
+                                if (!mVerticalTouchActive) {
+                                    if (Math.abs(yChanged / screenConfig.yRange) >= 0.05)
+                                    {
+                                        mVerticalTouchActive = true
+                                        mTouchY = event.rawY
+                                        mTouchX = event.rawX
+                                    }
+                                    return false
+                                }
                                 mTouchY = event.rawY
                                 mTouchX = event.rawX
                                 doVerticalTouchAction(yChanged)

--- a/vlc-android/src/org/videolan/vlc/gui/video/VideoTouchDelegate.kt
+++ b/vlc-android/src/org/videolan/vlc/gui/video/VideoTouchDelegate.kt
@@ -262,7 +262,7 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
     private fun doVolumeTouch(y_changed: Float) {
         if (mTouchAction != TOUCH_NONE && mTouchAction != TOUCH_VOLUME) return
         val audioMax = player.audioMax
-        val delta = -(y_changed / screenConfig.metrics.heightPixels.toFloat() * audioMax)
+        val delta = -(y_changed / screenConfig.metrics.heightPixels.toFloat() * audioMax * 1.25f)
         player.volume += delta
         val vol = Math.min(Math.max(player.volume, 0f), (audioMax * if (player.isAudioBoostEnabled) 2 else 1).toFloat()).toInt()
         if (delta < 0) player.originalVol = vol.toFloat()
@@ -298,7 +298,7 @@ class VideoTouchDelegate(private val player: VideoPlayerActivity,
         mTouchAction = TOUCH_BRIGHTNESS
 
         // Set delta : 2f is arbitrary for now, it possibly will change in the future
-        val delta = -ychanged / screenConfig.yRange
+        val delta = -ychanged / screenConfig.yRange * 1.25f
 
         player.changeBrightness(delta)
     }


### PR DESCRIPTION
Hi,
Existing vertical touch gestures have some limitations and can be improved to look more appealing.
Volume and brightness can be only changes in uneven chunks in range of 5-7% on my phone, there is no way to fine tune (even just to see nice rounded percent value), another issue is that gestures feel unresponsive - even a long swipe changes value not that much.

This will improve brightness gesture and allow 1% changes, but volume will still jump in 5-7% percent increments