### PR TITLE
l10n: remove last line gap

### DIFF
--- a/vlc-android/res/values-ar/strings.xml
+++ b/vlc-android/res/values-ar/strings.xml
@@ -243,6 +243,7 @@
     <string name="playback_speed_summary">تذكّر سرعة التشغيل التي ضبطتُها</string>
 
     <string name="play_button">زر التشغيل</string>
+
     <!-- Tips -->
     <string name="video_player_tips">نصائح حول مُشغّل المرئيات :</string>
     <string name="seek">سعي</string>

--- a/vlc-android/res/values-ar/strings.xml
+++ b/vlc-android/res/values-ar/strings.xml
@@ -413,4 +413,4 @@
     <string name="videos_all">كل الفيديوهات</string>
     <string name="tv_my_new_videos">فيديوهاتي الجديدة </string>
     <string name="next">التالي</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ast/strings.xml
+++ b/vlc-android/res/values-ast/strings.xml
@@ -169,4 +169,4 @@
     <string name="enable_verbose_mode">Detalláu</string>
     <string name="enable_verbose_mode_summary">Incrementar el nivel de detalle (logcat)</string>
     <string name="next">Siguiente</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ast/strings.xml
+++ b/vlc-android/res/values-ast/strings.xml
@@ -151,7 +151,6 @@
     <string name="about">Tocante a</string>
     <string name="about_text">VLC p\'Android™ ye una aplicación portada de VLC media player, l\'afamáu reproductor multimedia de códigu abiertu. La versión p\'Android™ que pue lleer la mayoría de los ficheros y fluxos na rede.</string>
     <string name="compiled_by">Esta versión de VLC ta compilada por:</string>
-
     <string name="general_prefs_category">Xeneral</string>
     <string name="automatic">Automática</string>
     <string name="screen_orientation_portrait">Retratu</string>

--- a/vlc-android/res/values-be/strings.xml
+++ b/vlc-android/res/values-be/strings.xml
@@ -171,7 +171,6 @@
     <string name="about">Апісанне праграмы</string>
     <string name="about_text">VLC для Android™ — гэта порт VLC, папулярнага адкрытага медыяплэера. Версія для Android™ можа чытаць бальшыню файлаў і сеткавых патокаў.</string>
     <string name="compiled_by">Гэта версія VLC скампілявана:</string>
-
     <string name="general_prefs_category">Агульныя</string>
     <string name="directories_summary">Абярыце каталогі для ўключэння ў медыятэку</string>
     <string name="add_custom_path">Дадаць свой шлях</string>

--- a/vlc-android/res/values-be/strings.xml
+++ b/vlc-android/res/values-be/strings.xml
@@ -254,4 +254,4 @@
     <string name="drawer_open">Адкрыць панэль навігацыі</string>
     <string name="drawer_close">Закрыць панэль навігацыі</string>
     <string name="next">Наступны</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-bn-rBD/strings.xml
+++ b/vlc-android/res/values-bn-rBD/strings.xml
@@ -118,4 +118,4 @@
     <string name="clear_log">লগ পরিষ্কার করুন</string>
     <string name="copy_to_clipboard">ক্লিপবোর্ডে অনুলিপি করুন</string>
     <string name="next">পরবর্তী</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-bn-rIN/strings.xml
+++ b/vlc-android/res/values-bn-rIN/strings.xml
@@ -2,12 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Main VLC Interface -->
-    <string name="ok">	
-ঠিক আছে</string>
-    <string name="cancel">	
-রদ করা</string>
-    <string name="other">	
-অন্য</string>
+    <string name="ok">ঠিক আছে</string>
+    <string name="cancel">রদ করা</string>
+    <string name="other">অন্য</string>
     <string name="sortby">সাজান…</string>
     <string name="sortby_name">নাম</string>
     <string name="sortby_artist_name">শিল্পী</string>
@@ -95,7 +92,6 @@
     <string name="about">সম্পর্কে</string>
     <string name="about_text">অ্যানড্রইড ™ জন্য VLC হয় VLC মিডিয়া প্লেয়ার, জনপ্রিয় ওপেন সোর্স মিডিয়া প্লেয়ার একটি বন্দর. অ্যানড্রইড ™ সংস্করণে সর্বাধিক ফাইল এবং নেটওয়ার্ক স্ট্রিম পড়তে পারেন.</string>
     <string name="compiled_by">VLC \'র এই সংস্করণ দ্বারা কম্পাইল করা হয়:</string>
-
     <string name="automatic">স্বয়ংক্রিয়</string>
     <string name="enable_headset_detection">হেডসেট সনাক্ত করুন</string>
     <string name="aout">অডিও আউটপুট</string>

--- a/vlc-android/res/values-bn-rIN/strings.xml
+++ b/vlc-android/res/values-bn-rIN/strings.xml
@@ -109,4 +109,4 @@
     <string name="enable_verbose_mode">বাগ্বহুল</string>
     <string name="enable_verbose_mode_summary">ভার্বোসিটি (logcat) বাড়ান</string>
     <string name="next">পরবর্তী</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-br/strings.xml
+++ b/vlc-android/res/values-br/strings.xml
@@ -396,4 +396,4 @@
     <string name="download_the_selected">Pellgargañ an diuzadenn</string>
     <string name="next">War-lerc\'h</string>
     <string name="download">Pellgargañ</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-br/strings.xml
+++ b/vlc-android/res/values-br/strings.xml
@@ -234,6 +234,7 @@
     <string name="playback_speed_summary">Dalc\'hit soñj eus an tizh lenn ho peus termenet</string>
 
     <string name="play_button">Bouton Lenn</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Alioù al lenner video:</string>
     <string name="seek">Klask</string>
@@ -371,6 +372,7 @@
     <string name="playlist_save">Enrollañ ar roll-lenn</string>
     <string name="go_to_chapter">Mont d\'ar chabistr...</string>
     <string name="chapter">Chabistr</string>
+
     <!-- Accessibility -->
     <string name="more_actions">Muioc\'h a oberoù</string>
     <string name="move">Fiñval</string>
@@ -379,8 +381,10 @@
     <string name="allow_settings_access_ringtone_description">VLC en deus ezhomm ec\'h aotrefec\'h an arload-mañ evit lakaat ar ganaouenn-mañ evel soniri.</string>
     <string name="allow_settings_access_brightness_title">Aotren VLC da cheñch ar mod lintr</string>
     <string name="allow_settings_access_brightness_description">VLC en deus ezhomm ec\'h aotrefec\'h an arload-mañ da cheñch al lintr.</string>
+
     <!-- fast scroller -->
     <string name="fastscroller_track">Roud FastScroller</string>
+
     <!-- Plugins -->
     <string name="plugins">Lugantoù</string>
     <string name="extension_empty">Elfenn ebet da ziskouez, kit da arventennoù hoc\'h astennoù evit kaout un nebeud re.</string>

--- a/vlc-android/res/values-bs/strings.xml
+++ b/vlc-android/res/values-bs/strings.xml
@@ -164,7 +164,6 @@
     <string name="about">O nama</string>
     <string name="about_text">VLC za Android™ je port VLC medijskog izvođača, popularnog medijskog izvođača otvorenog koda. Android™ verzija može čitati većinu datoteka i mrežnih strujanja.</string>
     <string name="compiled_by">Ova verzija VLC-a je kompajlirana od strane:</string>
-
     <string name="general_prefs_category">Opće</string>
     <string name="directories_summary">Izaberi direktorije za uključivanje u medijskoj biblioteci</string>
     <string name="add_custom_path">Dodaj prilagođen put</string>
@@ -205,9 +204,7 @@
     <string name="aout_summary">Izmijeni način na koji VLC koristi izlazni zvuk.</string>
     <string name="performance_prefs_category">Performansa</string>
     <string name="chroma_format">Forsiraj video krom</string>
-    <string name="chroma_format_summary">RGB 32-bit: zadana kroma
-RGB 16-bit: bolja performansa ali slabiji kvalitet
-YUV: najbolja performansa ali ne radi na svim uređajima. Android 2.3 i novije.</string>
+    <string name="chroma_format_summary">RGB 32-bit: zadana kroma\nRGB 16-bit: bolja performansa ali slabiji kvalitet\nYUV: najbolja performansa ali ne radi na svim uređajima. Android 2.3 i novije.</string>
     <string name="deblocking">Postavke filtera za deblokiranje</string>
     <string name="deblocking_summary">Izmijeni postavke filtera za deblokiranje. Moguće poboljšanje kvalitete videa. Samo za napredne korisnike.</string>
     <string name="deblocking_always">Puno deblokiranje (najsporije)</string>

--- a/vlc-android/res/values-bs/strings.xml
+++ b/vlc-android/res/values-bs/strings.xml
@@ -251,4 +251,4 @@ YUV: najbolja performansa ali ne radi na svim uređajima. Android 2.3 i novije.<
     <string name="resume_from_position">Nastavi sa zadnje pozicije</string>
     <string name="confirm_resume">Nastavi sa zadnje pozicije?</string>
     <string name="next">Sljedeće</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ca/strings.xml
+++ b/vlc-android/res/values-ca/strings.xml
@@ -212,6 +212,7 @@
     <string name="playback_speed_summary">Recorda la velocitat de reproducció configurada</string>
 
     <string name="play_button">Botó de reproducció</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Consells del reproductor de vídeo:</string>
     <string name="seek">Cerca</string>
@@ -401,6 +402,7 @@
     <string name="go_to_chapter">Vés al capítol…</string>
     <string name="chapter">Capítol</string>
     <string name="directory_empty">El directori és buit</string>
+
     <!-- Accessibility -->
     <string name="more_actions">Més accions</string>
     <string name="move">Mou</string>

--- a/vlc-android/res/values-ca/strings.xml
+++ b/vlc-android/res/values-ca/strings.xml
@@ -426,4 +426,4 @@
     <string name="recommendations">Recomanacions</string>
     <string name="browser_quick_access">Accés ràpid</string>
     <string name="next">Endavant</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-co/strings.xml
+++ b/vlc-android/res/values-co/strings.xml
@@ -605,4 +605,4 @@
     <string name="rename">Rinumà</string>
     <string name="rename_media">Rinumà %1$s</string>
     <string name="next">Seguente</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-co/strings.xml
+++ b/vlc-android/res/values-co/strings.xml
@@ -211,6 +211,7 @@
     <string name="playback_speed_summary">Cunservà a vitezza di ripruduzzione d\'una video à l\'altra</string>
 
     <string name="play_button">Buttone Sunà</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Minichichje di u lettore video :</string>
     <string name="seek">Pusiziunà</string>

--- a/vlc-android/res/values-cs/strings.xml
+++ b/vlc-android/res/values-cs/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">Pamatovat si nastavenou rychlost přehrávání</string>
 
     <string name="play_button">Tlačítko přehrát</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Tipy přehrávače videa:</string>
     <string name="seek">Posun</string>

--- a/vlc-android/res/values-cy/strings.xml
+++ b/vlc-android/res/values-cy/strings.xml
@@ -656,4 +656,4 @@
     <string name="onboarding_scan_whole">Bydd VLC yn sganio fy ngherdyn SD cyfan</string>
     <string name="onboarding_scan_customize">Gadael i mi ddewis pa ffolderi bydd VLC yn eu sganio</string>
     <string name="light_theme">Thema olau</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-cy/strings.xml
+++ b/vlc-android/res/values-cy/strings.xml
@@ -231,6 +231,7 @@
     <string name="playback_speed_summary">Cofio\'r cyflymder chwarae wyt ti\'n ei osod</string>
 
     <string name="play_button">Botwm Chwarae</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Awgrymiadau chwaraeydd fideo:</string>
     <string name="seek">Canfod</string>

--- a/vlc-android/res/values-da/strings.xml
+++ b/vlc-android/res/values-da/strings.xml
@@ -637,4 +637,4 @@
     <string name="ctx_player_subs_track">Undertekstspor</string>
     <string name="ctx_player_tracks_title">Mediespor</string>
     <string name="ctx_pip_title">Pop op-afspiller</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-da/strings.xml
+++ b/vlc-android/res/values-da/strings.xml
@@ -215,6 +215,7 @@
     <string name="playback_speed_summary">Husk den afspilningshastighed du har sat</string>
 
     <string name="play_button">Afspil-knap</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Tips til videoafspilleren:</string>
     <string name="seek">Søg</string>

--- a/vlc-android/res/values-de/strings.xml
+++ b/vlc-android/res/values-de/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Eingestellte Wiedergabegeschwindigkeit wird gespeichert</string>
 
     <string name="play_button">Wiedergabe-Knopf</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Filmwiedergabetipps:</string>
     <string name="seek">Suchen</string>

--- a/vlc-android/res/values-de/strings.xml
+++ b/vlc-android/res/values-de/strings.xml
@@ -247,6 +247,7 @@
     <string name="about_text">VLC für Android™ ist eine Portierung des VLC media players, dem beliebten quelloffenen Mediaplayer. Die Android™-Version kann die meisten Dateien und Netzwerk-Streams lesen.</string>
     <string name="vlc_authors">und VLC-Autoren.</string>
     <string name="compiled_by">Diese Version von VLC wurde kompiliert von:</string>
+    <string name="feedback_forum">Bewertungsportal</string>
 
     <!-- Preferences -->
     <string name="preferences">Einstellungen</string>
@@ -680,4 +681,6 @@
     <string name="device_default">Systemsprache</string>
     <string name="track_number">%s Titel</string>
     <string name="jump_to">Springe zu</string>
+    <string name="show_video_thumbnails_summary">Video-Vorschau in Listen anzeigen</string>
+    <string name="show_video_thumbnails">Video-Vorschau</string>
 </resources>

--- a/vlc-android/res/values-el/strings.xml
+++ b/vlc-android/res/values-el/strings.xml
@@ -216,6 +216,7 @@
     <string name="playback_speed_summary">Διατήρηση μνήμης ταχήτητας αναπαραγωγής</string>
 
     <string name="play_button">Κουμπί αναπαραγωγής</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Συμβουλές αναπαραγωγής βίντεο:</string>
     <string name="seek">Εύρεση</string>

--- a/vlc-android/res/values-el/strings.xml
+++ b/vlc-android/res/values-el/strings.xml
@@ -617,4 +617,4 @@
     <string name="onboarding_scan_whole">Το VLC θα σαρώνει όλη την SD Card μου</string>
     <string name="onboarding_scan_customize">Επίτρεψέ μου να επιλέξω ποιους φακέλους θα σαρώνει το VLC</string>
     <string name="light_theme">Ανοιχτό θέμα</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-en-rGB/strings.xml
+++ b/vlc-android/res/values-en-rGB/strings.xml
@@ -240,4 +240,4 @@
     <string name="drawer_open">Open navigation drawer</string>
     <string name="drawer_close">Close navigation drawer</string>
     <string name="next">Next</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-en-rGB/strings.xml
+++ b/vlc-android/res/values-en-rGB/strings.xml
@@ -157,7 +157,6 @@
     <string name="about">About</string>
     <string name="about_text">VLC for Android™ is a port of VLC media player, the popular open source media player. The Android™ version can read most files and network streams.</string>
     <string name="compiled_by">This version of VLC is compiled by:</string>
-
     <string name="general_prefs_category">General</string>
     <string name="directories_summary">Select directories to include in the media library</string>
     <string name="add_custom_path">Add a custom path</string>

--- a/vlc-android/res/values-es-rMX/strings.xml
+++ b/vlc-android/res/values-es-rMX/strings.xml
@@ -254,4 +254,4 @@
     <string name="drawer_open">Abrir caja de navegacion</string>
     <string name="drawer_close">Cerrar caja de navegacion</string>
     <string name="next">Siguiente</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-es-rMX/strings.xml
+++ b/vlc-android/res/values-es-rMX/strings.xml
@@ -171,7 +171,6 @@
     <string name="about">Acerca de</string>
     <string name="about_text">VLC para Android™ es una reescritura del Reproductor multimedia VLC, el popular reproductor multimedia de código abierto. La versión para Android™ puede leer la mayoría de archivos y flujos de red.</string>
     <string name="compiled_by">Esta versión de VLC está compilada por:</string>
-
     <string name="general_prefs_category">General</string>
     <string name="directories_summary">Seleccionar directorios a incluir en la librería multimedia</string>
     <string name="add_custom_path">Añadir una ruta personalizada</string>

--- a/vlc-android/res/values-es/strings.xml
+++ b/vlc-android/res/values-es/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">VLC para Android™ es una reescritura del Reproductor multimedia VLC, el popular reproductor multimedia de código abierto. La versión de Android™ puede leer la mayoría de archivos y flujos de red.</string>
     <string name="vlc_authors">y autores VLC.</string>
     <string name="compiled_by">Esta versión de VLC está compilada por:</string>
+    <string name="feedback_forum">Foro de comentarios</string>
 
     <!-- Preferences -->
     <string name="preferences">Preferencias</string>
@@ -681,4 +682,6 @@
     <string name="device_default">Dispositivo por defecto</string>
     <string name="track_number">%s pistas</string>
     <string name="jump_to">Saltar a</string>
+    <string name="show_video_thumbnails_summary">Mostrar previsualización de vídeos en listas</string>
+    <string name="show_video_thumbnails">Previsualización de vídeo</string>
 </resources>

--- a/vlc-android/res/values-es/strings.xml
+++ b/vlc-android/res/values-es/strings.xml
@@ -679,4 +679,5 @@
     <string name="popup_force_legacy_summary">Usar ventana emergente escalable en modo vídeo sobre vídeo personalizado</string>
     <string name="device_default">Dispositivo por defecto</string>
     <string name="track_number">%s pistas</string>
+    <string name="jump_to">Saltar a</string>
 </resources>

--- a/vlc-android/res/values-es/strings.xml
+++ b/vlc-android/res/values-es/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Recordar la velocidad de reproducción establecida</string>
 
     <string name="play_button">Botón reproducir</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Consejos del reproductor de vídeo:</string>
     <string name="seek">Buscar</string>

--- a/vlc-android/res/values-et/strings.xml
+++ b/vlc-android/res/values-et/strings.xml
@@ -172,4 +172,4 @@
     <string name="copied_to_clipboard">Logi lõikepuhvrisse kopeeritud.</string>
     <string name="restart_vlc">Taaskäivita VLC</string>
     <string name="next">Järgmine</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-et/strings.xml
+++ b/vlc-android/res/values-et/strings.xml
@@ -123,7 +123,6 @@
     <string name="about">Programmist</string>
     <string name="about_text">VLC Androidile™ on avatud lähtekoodiga populaarse VLC meediaesitaja port. Androidi™ versioon suudab avada enamikke meediafaile ja võrguvoogusid.</string>
     <string name="compiled_by">Selle VLC versiooni kompileerisid:</string>
-
     <string name="general_prefs_category">Üldine</string>
     <string name="directories_summary">Vali katalooge, mida lisada meediakogusse</string>
     <string name="add_custom_path">Kohandatud raja lisamine</string>

--- a/vlc-android/res/values-eu/strings.xml
+++ b/vlc-android/res/values-eu/strings.xml
@@ -212,6 +212,7 @@
     <string name="playback_speed_summary">Gogoratu ezarritako erreprodukzio-abiadura</string>
 
     <string name="play_button">Play Botoia</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Bideo-erreproduzigailuaren aholkuak:</string>
     <string name="seek">Saltatu</string>

--- a/vlc-android/res/values-eu/strings.xml
+++ b/vlc-android/res/values-eu/strings.xml
@@ -627,4 +627,4 @@
     <string name="ctx_player_subs_track">Azpitituluen pista</string>
     <string name="ctx_player_tracks_title">Multimedia pistak</string>
     <string name="device_dialog_title">Kanpoko gailua txertatua</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-fa/strings.xml
+++ b/vlc-android/res/values-fa/strings.xml
@@ -217,6 +217,7 @@
     <string name="playback_speed_summary">یادآوری سرعت پخشی که شما قرار داده‌اید</string>
 
     <string name="play_button">کلید پخش</string>
+
     <!-- Tips -->
     <string name="video_player_tips">راهنمایی‌های پخش کننده تصویری:</string>
     <string name="seek">گشتن</string>

--- a/vlc-android/res/values-fa/strings.xml
+++ b/vlc-android/res/values-fa/strings.xml
@@ -386,15 +386,53 @@
     <string name="file_size">اندازه فایل:</string>
 
     <string name="search_hint">جستجوی رسانه</string>
+    <string name="search_list_hint">جستجوی محتوا در لیست فعلی</string>
+    <string name="search_global">جستجو در تمام کتابخانه</string>
+    <string name="directory_show_medialib">نمایش در MediaLib</string>
+    <string name="directory_hide_medialib">پنهان‌سازی از MediaLib</string>
+    <string name="playlist_save">ذخیره صورتپخش</string>
+    <string name="playlist_name_hint">نام صورتپخش</string>
+    <string name="go_to_chapter">برو به باب...</string>
+    <string name="chapter">باب</string>
     <string name="resume_from_position">پخش از آخرین موقعیت</string>
     <string name="confirm_resume">پخش از آخرین موقعیت؟</string>
+    <string name="confirm_resume_title">درخواست تائیدیه برای ادامه</string>
+    <string name="confirm_resume_summary">اگر فعال شود، از شما درخواست تایید برای از سرگیری پخش از آخرین موقعیت ویدیو می‌کند.</string>
     <string name="directory_empty">پوشه خالی است</string>
+    <string name="tv_ui_title">میانای Android TV</string>
+    <string name="tv_ui_summary">میانای کاربری را به پوسته سازگار با TV تغییر بده</string>
+    <string name="medialibrary">کتابخانه رسانه‌ای</string>
+    <string name="medialibrary_directories">پوشه‌های کتابخانه رسانه‌ای</string>
+
+    <!-- Accessibility -->
+    <string name="more_actions">کنش‌های دیگر</string>
     <string name="move">حرکت</string>
+    <string name="back_quit_lock">برای خروج دکمه بازگشت را دوباره بزنید.</string>
+    <string name="playlist_deleted">صورتپخش حذف شد</string>
     <string name="file_deleted">فایل حذف شده است</string>
     <string name="no_subs_found">زیرنویسی در این پوشه یافت نشد</string>
-    <string name="music_now_playing">هم اکنون در حال پخش</string>
+    <string name="music_now_playing">در حال پخش</string>
 
+    <!-- Widget -->
+    <string name="widget_name_w">ابزارک سفید VLC</string>
+    <string name="widget_name_b">ابزارک تیره VLC</string>
+    <string name="allow_storage_access_title">اجازه دسترسی VLC به فایل‌های صوتی و تصویری را دهید.</string>
+    <string name="allow_storage_access_description">VLC نیاز دارد تا توسط شما مجاز شود به دسترسی به فایل‌های رسانه ای.</string>
+    <string name="allow_settings_access_ringtone_title">VLC را برای تغییر آهنگ زنگ مجاز کنید</string>
+    <string name="allow_settings_access_ringtone_description">VLC نیاز دارد تا توسط شما مجاز شود به تغییر آهنگ زنگ.</string>
+    <string name="allow_settings_access_brightness_title">VLC را مجاز کن تا حالت روشنایی را تغییر دهد.</string>
+    <string name="allow_settings_access_brightness_description">VLC نیاز دارد تا توسط شما مجاز شود تا حالت روشنایی را تغییر دهد.</string>
+    <string name="allow_draw_overlays_title">پخش کننده VLC را مجاز کن تا بر اپ‌های دیگر ظاهر شود.</string>
+    <string name="allow_sdraw_overlays_description">VLC نیاز دارد تا توسط شما مجاز شود تا بر اپلیکیشن‌های دیگر ظاهر شود.</string>
+    <string name="permission_ask_again">اجازه دسترسی</string>
+    <string name="exit_app">بستن VLC</string>
+    <string name="exit_app_msg">آیا برای بستن VLC اطمینان داری؟</string>
+
+    <!-- Plugins -->
+    <string name="plugins">افزونه‌ها</string>
     <string name="download_on_device">دانلود</string>
+    <string name="extension_empty">موردی برای نمایش وجوذ ندارد، به تنظیمات توسعه رفته و چندتا بگیر.</string>
+
     <string name="opengl_automatic">خودکار</string>
     <string name="downloading_subtitles">در حال بارگیری زیرنویس ها</string>
     <string name="listen">گوش دادن</string>
@@ -431,4 +469,4 @@
     <string name="otg_device_title">دستگاه OTG</string>
     <string name="browser">بروزر</string>
     <string name="next">بعدی</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-fi/strings.xml
+++ b/vlc-android/res/values-fi/strings.xml
@@ -352,4 +352,4 @@
     <string name="drawer_open">Avaa navigointilaatikko</string>
     <string name="drawer_close">Sulje navigointilaatikko</string>
     <string name="next">Seuraava</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-fo/strings.xml
+++ b/vlc-android/res/values-fo/strings.xml
@@ -240,4 +240,4 @@
     <string name="drawer_open">Lat navigatiónsskuffuna upp</string>
     <string name="drawer_close">Lat navigatiónsskuffuna aftur</string>
     <string name="next">Næsta</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-fo/strings.xml
+++ b/vlc-android/res/values-fo/strings.xml
@@ -157,7 +157,6 @@
     <string name="about">Um</string>
     <string name="about_text">VLC til Android™ er eitt portur hjá VLC margmiðlaspælaranum, tí víða gitta open-source spælaranum. Android™ útgávan klárar at lesa flestu fílur og kann stroyma flestu keldur.</string>
     <string name="compiled_by">Henda útgáva av VLC verður umsett av:</string>
-
     <string name="general_prefs_category">Yvirskipað</string>
     <string name="directories_summary">Vel fíluskráir av hava við í miðlasavninum</string>
     <string name="add_custom_path">Legg sjálvvalda rás afturat</string>

--- a/vlc-android/res/values-fr/strings.xml
+++ b/vlc-android/res/values-fr/strings.xml
@@ -679,4 +679,5 @@
     <string name="popup_force_legacy_summary">Utiliser une fenêtre personnalisée de Picture-in-Picture redimensionnable</string>
     <string name="device_default">Périphérique prédéfini</string>
     <string name="track_number">%s pistes</string>
+    <string name="jump_to">Aller à</string>
 </resources>

--- a/vlc-android/res/values-fr/strings.xml
+++ b/vlc-android/res/values-fr/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Conserver la vitesse de lecture d\'une vidéo à l\'autre</string>
 
     <string name="play_button">Bouton Jouer</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Astuces du lecteur vidéo :</string>
     <string name="seek">Naviguer</string>

--- a/vlc-android/res/values-fy/strings.xml
+++ b/vlc-android/res/values-fy/strings.xml
@@ -79,4 +79,4 @@
     <string name="advanced_prefs_category">Avansearre</string>
     <string name="developer_prefs_category">Untwikkeler</string>
     <string name="next">Folgjende</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-gd/strings.xml
+++ b/vlc-android/res/values-gd/strings.xml
@@ -152,7 +152,6 @@
     <string name="about">Mu dheidhinn</string>
     <string name="about_text">Tha VLC airson Android™ \'na phort de chluicheadair mheadhanan VLC, cluicheadaire le còd fosgailte air a bheil fèill mhòr. Cluichidh an tionndadh Android™ a\' mhòrchuid dhe na faidhlichean is sruthan lìonraidh.</string>
     <string name="compiled_by">Chaidh an tionndadh seo de VLC a thrusadh le:</string>
-
     <string name="general_prefs_category">Coitcheann</string>
     <string name="directories_summary">Tagh pasgan a thèid a ghabhail a-steach ann an leabharlann nam meadhan</string>
     <string name="add_custom_path">Cuir slighe ghnàthaichte ris</string>

--- a/vlc-android/res/values-gd/strings.xml
+++ b/vlc-android/res/values-gd/strings.xml
@@ -226,4 +226,4 @@
 
     <string name="tv_my_new_videos">Videothan ùra</string>
     <string name="next">Air adhart</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-gl/strings.xml
+++ b/vlc-android/res/values-gl/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Lembrar a veloc. de reprodución que escollida</string>
 
     <string name="play_button">Botón de reprodución</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Suxestións para o reprodutor de vídeo:</string>
     <string name="seek">Buscar</string>

--- a/vlc-android/res/values-gu-rIN/strings.xml
+++ b/vlc-android/res/values-gu-rIN/strings.xml
@@ -111,4 +111,4 @@
     <string name="enable_verbose_mode">શબ્લબહુલ</string>
     <string name="enable_verbose_mode_summary">આ વર્બોઝીટી (logcat) વધારો</string>
     <string name="next">પછીનું</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-gu-rIN/strings.xml
+++ b/vlc-android/res/values-gu-rIN/strings.xml
@@ -28,9 +28,8 @@
     <string name="unknown_album">અજ્ઞાત આલ્બમ</string>
     <string name="unknown_genre">અજ્ઞાત શૈલી</string>
     <plurals name="songs_quantity">
-        <item quantity="one">એક: 1 ગીત
-</item>
-        <item quantity="other">અન્ય:  ગીતો \n </item>
+        <item quantity="one">એક: 1 ગીત</item>
+        <item quantity="other">અન્ય: %d ગીતો</item>
     </plurals>
 
     <string name="artists">આર્ટિસ્ટ</string>
@@ -83,6 +82,7 @@
     <string name="search">શોધો</string>
     <string name="subtitles">ઉપશીર્ષકો</string>
     <string name="options">વિકલ્પો</string>
+
     <!-- About -->
     <string name="app_name_full">Android™ માટે VLC</string>
     <string name="licence">લાઇસન્સ</string>
@@ -90,7 +90,6 @@
     <string name="about">લગભગ</string>
     <string name="about_text">Android ™ માટે VLC મીડિયા પ્લેયર, લોકપ્રિય ઓપન સોર્સ મીડિયા પ્લેયર એક બંદર છે. ફક્ત Android ™ આવૃત્તિ મોટા ભાગના ફાઈલો અને નેટવર્ક સ્ટ્રીમ્સ વાંચી શકે છે.</string>
     <string name="compiled_by">વીએલસીનુ સંસ્કરણ આના દ્વારા સંકલિત છે:</string>
-
     <string name="general_prefs_category">સામાન્ય</string>
     <string name="hardware_acceleration">હાર્ડવેર પ્રવેગ</string>
     <string name="automatic">સ્વ્નીયાન્ત્ર્ણ</string>

--- a/vlc-android/res/values-he/strings.xml
+++ b/vlc-android/res/values-he/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">לזכור את מהירות הנגינה שהגדרת</string>
 
     <string name="play_button">כפתור נגינה</string>
+
     <!-- Tips -->
     <string name="video_player_tips">עצות לנגן הווידאו:</string>
     <string name="seek">גלילה</string>

--- a/vlc-android/res/values-he/strings.xml
+++ b/vlc-android/res/values-he/strings.xml
@@ -693,4 +693,5 @@
     <string name="popup_force_legacy_summary">להשתמש בחלונית צפה גמישה מותאמת לתמונה בתוך תמונה</string>
     <string name="device_default">בררת המחדל של המכשיר</string>
     <string name="track_number">%s רצועות</string>
+    <string name="jump_to">קפיצה אל</string>
 </resources>

--- a/vlc-android/res/values-hi/strings.xml
+++ b/vlc-android/res/values-hi/strings.xml
@@ -194,4 +194,4 @@
 
     <string name="save">सहेजें</string>
     <string name="next">अगला</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-hi/strings.xml
+++ b/vlc-android/res/values-hi/strings.xml
@@ -139,7 +139,6 @@
     <string name="about">के संबंध में</string>
     <string name="about_text">VLCAndroid ™ के लिए  VLC मीडिया प्लेयर,लोकप्रिय मुक्त स्रोत मीडिया प्लेयर का एक अनुभाग है | Android ™ संस्करण ज्यादातर फ़ाइलें और संजाल धाराओं को पढ़ सकता है.</string>
     <string name="compiled_by">VLC का यह संस्करण इनके द्वारा संकलित किया गया है:</string>
-
     <string name="directories_summary">मीडिया लाइब्रेरी में शामिल करने के लिए निर्देशिका का चयन करें</string>
     <string name="add_custom_path">एक कस्टम पथ जोड़ें</string>
     <string name="add_custom_path_description">स्कैन करने के लिए अतिरिक्त कस्टम निर्देशिका दर्ज करें:</string>

--- a/vlc-android/res/values-hr/strings.xml
+++ b/vlc-android/res/values-hr/strings.xml
@@ -565,4 +565,4 @@
     <string name="dialog_sd_wizard">Prikaži mi</string>
     <string name="renderers_disconnect">Prekini povezivanje</string>
     <string name="next">Sljedeće</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-hu/strings.xml
+++ b/vlc-android/res/values-hu/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Emlékezzen a beállított lejátszási sebességre</string>
 
     <string name="play_button">Lejátszás gomb</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Lejátszó tippek:</string>
     <string name="seek">Keresés</string>

--- a/vlc-android/res/values-hu/strings.xml
+++ b/vlc-android/res/values-hu/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">A VLC for Android™ a népszerű nyílt forráskódú VLC médialejátszó androidos változata. Ez a változat képes a legtöbb fájlból és hálózati forrásból lejátszani.</string>
     <string name="vlc_authors">és a VLC szerzői.</string>
     <string name="compiled_by">Ezt a VLC verziót készítették:</string>
+    <string name="feedback_forum">Visszajelző fórum</string>
 
     <!-- Preferences -->
     <string name="preferences">Beállítások</string>
@@ -681,4 +682,6 @@
     <string name="device_default">Eszköz alapértelmezése</string>
     <string name="track_number">%s szám</string>
     <string name="jump_to">Ugrás</string>
+    <string name="show_video_thumbnails_summary">Videó bélyegképek megjelenítése a listákban</string>
+    <string name="show_video_thumbnails">Videó bélyegképek</string>
 </resources>

--- a/vlc-android/res/values-id/strings.xml
+++ b/vlc-android/res/values-id/strings.xml
@@ -315,4 +315,4 @@
     <string name="next">Selanjutya</string>
     <string name="ctx_player_audio_track">Trek audio</string>
     <string name="ctx_player_subs_track">Trek terjemahan</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-is/strings.xml
+++ b/vlc-android/res/values-is/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Muna afspilunarhraðann sem þú stilltir</string>
 
     <string name="play_button">Afspilunarhnappur</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Ábendingar myndskeiðaspilara:</string>
     <string name="seek">Leita</string>

--- a/vlc-android/res/values-is/strings.xml
+++ b/vlc-android/res/values-is/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">VLC fyrir Android™ er yfirfærð útgáfa af VLC margmiðlunarspilaranum, eins vinsælasta oppna/frjálsa margmiðlunarspilarans. Android™ útgáfan getur lesið flestar skrár og netstreymi.</string>
     <string name="vlc_authors">og höfundar VLC.</string>
     <string name="compiled_by">Þessi útgáfa af VLC var vistþýdd af:</string>
+    <string name="feedback_forum">Umfjöllun á spjallvef</string>
 
     <!-- Preferences -->
     <string name="preferences">Stillingar</string>
@@ -681,4 +682,6 @@
     <string name="device_default">Sjálfgefið á tæki</string>
     <string name="track_number">%s lög</string>
     <string name="jump_to">Hoppa á</string>
+    <string name="show_video_thumbnails_summary">Sýna smámyndir myndskeiða í listum</string>
+    <string name="show_video_thumbnails">Smámyndir myndskeiða</string>
 </resources>

--- a/vlc-android/res/values-it/strings.xml
+++ b/vlc-android/res/values-it/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">VLC per Android™ è un port del lettore multimediale VLC, il popolare lettore multimediale open source. La versione per Android™ può leggere la maggior parte dei file e dei flussi di rete.</string>
     <string name="vlc_authors">e gli autori di VLC.</string>
     <string name="compiled_by">Questa versione di VLC è compilata da:</string>
+    <string name="feedback_forum">Forum per le segnalazioni</string>
 
     <!-- Preferences -->
     <string name="preferences">Impostazioni</string>
@@ -681,4 +682,6 @@
     <string name="device_default">Predefinito del dispositivo</string>
     <string name="track_number">%s tracce</string>
     <string name="jump_to">Salta a</string>
+    <string name="show_video_thumbnails_summary">Mostra le miniature dei video nell\'elenco</string>
+    <string name="show_video_thumbnails">Miniature dei video</string>
 </resources>

--- a/vlc-android/res/values-it/strings.xml
+++ b/vlc-android/res/values-it/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Ricorda la velocità di riproduzione impostata</string>
 
     <string name="play_button">Pulsante Riproduci</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Suggerimenti del lettore video:</string>
     <string name="seek">Posiziona</string>

--- a/vlc-android/res/values-ja/strings.xml
+++ b/vlc-android/res/values-ja/strings.xml
@@ -211,6 +211,7 @@
     <string name="playback_speed_summary">設定した再生速度を保存</string>
 
     <string name="play_button">再生ボタン</string>
+
     <!-- Tips -->
     <string name="video_player_tips">ビデオプレイヤーのTips:</string>
     <string name="seek">シーク</string>
@@ -240,6 +241,7 @@
     <string name="about_text">VLC for Android™ はポピュラーなオープンソースのメディアプレイヤーであるVLCメディアプレイヤーの移植版です。Android™ 版は多くのファイルとネットワークストリームを読み込むことが可能です。</string>
     <string name="vlc_authors">およびVLCの著作者。</string>
     <string name="compiled_by">このバージョンのVLCのコンパイラ:</string>
+    <string name="feedback_forum">フィードバックフォーム</string>
 
     <!-- Preferences -->
     <string name="preferences">設定</string>
@@ -673,4 +675,6 @@
     <string name="device_default">デバイスのデフォルト</string>
     <string name="track_number">%s トラック</string>
     <string name="jump_to">ジャンプ先</string>
+    <string name="show_video_thumbnails_summary">リストにビデオのサムネイルを表示</string>
+    <string name="show_video_thumbnails">ビデオサムネイル</string>
 </resources>

--- a/vlc-android/res/values-kab/strings.xml
+++ b/vlc-android/res/values-kab/strings.xml
@@ -159,4 +159,4 @@
     <string name="sending_log">Tuzzna n uɣmis…</string>
 
     <string name="next">Win ɣer-s</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-kab/strings.xml
+++ b/vlc-android/res/values-kab/strings.xml
@@ -106,7 +106,6 @@
     <string name="revision">Aceggeṛ</string>
     <string name="about">Ɣef</string>
     <string name="compiled_by">Lqem-agi n VLC yesefsa-t :</string>
-
     <string name="general_prefs_category">Amatu</string>
     <string name="directories_summary">Fren  ikaramen ara ternuḍ ɣer temkarḍit n imidyaten</string>
     <string name="add_custom_path">Rnu akaram</string>

--- a/vlc-android/res/values-km/strings.xml
+++ b/vlc-android/res/values-km/strings.xml
@@ -282,4 +282,4 @@
     <string name="file_size">ខ្នាតឯកសារ</string>
 
     <string name="next">បន្ទាប់</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-km/strings.xml
+++ b/vlc-android/res/values-km/strings.xml
@@ -184,7 +184,6 @@
     <string name="about">អំពី</string>
     <string name="about_text">VLC សម្រាប់ Android™ គឺ​ជា​កម្មវិធី​ចាក់​មេឌៀ VLC ដែល​ជា​កម្មវិធី​មេឌៀ​កូដ​ចំ​ហ​ដ៏​មាន​ប្រជាប្រិយ ។ Android™ អាច​អាន​ឯកសារ និង​​ស្ទ្រីម​បណ្ដាញ​​ភាគ​ច្រើន ។</string>
     <string name="compiled_by">VLC កំណែ​នេះ​ត្រូវ​បាន​ចងក្រង​ដោយ ៖</string>
-
     <string name="general_prefs_category">ទូទៅ</string>
     <string name="directories_summary">ជ្រើស​ថត ដើម្បី​ដាក់​បញ្ចូល​បណ្ណាល័យ​មេឌៀ</string>
     <string name="add_custom_path">បន្ថែម​ផ្លូវ​ផ្ទាល់​ខ្លួន</string>

--- a/vlc-android/res/values-kn/strings.xml
+++ b/vlc-android/res/values-kn/strings.xml
@@ -139,7 +139,6 @@
     <string name="about">ಇದರ ಬಗ್ಗೆ</string>
     <string name="about_text">Android™ಗಾಗಿ VLCಯು ಜನಪ್ರಿಯ ಮುಕ್ತ VLC ಮಾಧ್ಯಮ ತಂತ್ರಾಂಶದ Android™ನ ಅವತರಣಿಕೆ. Android™ನ ಆವೃತ್ತಿಯು ಅನೇಕ ಕಡತಗಳು ಮತ್ತು ನೆಟ್ವರ್ಕ್ ಸ್ಟ್ರೀಮ್ ಗಳನ್ನು ಆಡಿಸಬಲ್ಲದು.</string>
     <string name="compiled_by">VLCಯ ಈ ಆವೃತ್ತಿಯ ಸಂಕಲನಕಾರರು:</string>
-
     <string name="general_prefs_category">ಸಾಮಾನ್ಯ</string>
     <string name="directories_summary">ಮಾಧ್ಯಮ ಭಂಡಾರದಲ್ಲಿ ಸೇರಿಸಲು ಕೋಶಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
     <string name="add_custom_path">ಐಚ್ಚಿಕ ಪಥವನ್ನು ಸೇರಿಸಿ</string>

--- a/vlc-android/res/values-kn/strings.xml
+++ b/vlc-android/res/values-kn/strings.xml
@@ -198,4 +198,4 @@
     <string name="dump_logcat_success">Logcat ಅನ್ನು ಯಶಸ್ವಿಯಾಗಿ %1$s! ಗೆ ಡಂಪ್ ಮಾಡಲಾಗಿದೆ</string>
     <string name="dump_logcat_failure">Logcat ಡಂಪ್ ವಿಫಲವಾಗಿದೆ.</string>
     <string name="next">ಮುಂದಿನ</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ko/strings.xml
+++ b/vlc-android/res/values-ko/strings.xml
@@ -616,4 +616,4 @@
     <string name="download_the_selected">다운로드 선택</string>
     <string name="next">다음</string>
     <string name="download">다운로드</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ko/strings.xml
+++ b/vlc-android/res/values-ko/strings.xml
@@ -203,6 +203,7 @@
     <string name="playback_speed_summary">설정한 재생 속도를 기억합니다</string>
 
     <string name="play_button">재생 버튼</string>
+
     <!-- Tips -->
     <string name="video_player_tips">비디오 재생기 팁:</string>
     <string name="seek">탐색</string>

--- a/vlc-android/res/values-lt/strings.xml
+++ b/vlc-android/res/values-lt/strings.xml
@@ -185,6 +185,7 @@
 
 
     <string name="playback_history_title">Grojimo žurnalas</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Vaizdo leistuvės paaiškinimai:</string>
     <string name="subtitles">Subtitrai</string>
@@ -319,6 +320,7 @@
 
     <string name="permission_ask_again">Leisti</string>
     <string name="exit_app">Užverti VLC</string>
+
     <!-- Plugins -->
     <string name="plugins">Papildiniai</string>
     <string name="download_on_device">Parsisiųsti</string>

--- a/vlc-android/res/values-lt/strings.xml
+++ b/vlc-android/res/values-lt/strings.xml
@@ -340,4 +340,4 @@
     <string name="equalizer_new_preset_name">Naujas</string>
     <string name="browser_storages">Laikmenos</string>
     <string name="next">Tolesnis</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-lv/strings.xml
+++ b/vlc-android/res/values-lv/strings.xml
@@ -247,4 +247,4 @@
     <string name="browser_quick_access">Ātrā piekļuve</string>
     <string name="browser_storages">Glabātuves</string>
     <string name="next">Nākošais</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-lv/strings.xml
+++ b/vlc-android/res/values-lv/strings.xml
@@ -158,7 +158,6 @@
     <string name="about">Par</string>
     <string name="about_text">VLC priekš Android ™ ir osta no VLC multimediju atskaņotāja, populārā atvērtā koda multimediju atskaņotājs.Android ™ versiju var izlasīt lielāko failus un tīkla plūsmas.</string>
     <string name="compiled_by">Šī versija VLC tiek apkopota pēc:</string>
-
     <string name="general_prefs_category">Vispārīgi</string>
     <string name="directories_summary">Izvēlaties direktorijas, lai iekļautu multivides bibliotēku</string>
     <string name="add_custom_path">Pievienot pielāgotu ceļu</string>

--- a/vlc-android/res/values-ml/strings.xml
+++ b/vlc-android/res/values-ml/strings.xml
@@ -307,4 +307,4 @@
     <string name="dialog_sd_wizard">എനിക്ക് കാണിച്ചു തരൂ</string>
     <string name="renderers_disconnect">ബന്ധം വിച്ഛേദിക്കുക</string>
     <string name="next">അടുത്തത്</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ml/strings.xml
+++ b/vlc-android/res/values-ml/strings.xml
@@ -189,6 +189,7 @@
     <string name="remove_song">ഗാനം നീക്കം ചെയ്യുക</string>
     <string name="rearrange_order">ക്രമം പുനക്രമീകരിക്കുക</string>
     <string name="show_playlist">പ്ലേലിസ്റ്റ് കാണിക്കുക</string>
+
     <!-- About -->
     <string name="app_name_full">ആന്‍ഡ്രോയ്ഡിനുള്ള വിഎല്‍സി</string>
     <string name="licence">ലൈസന്‍സ്‌</string>

--- a/vlc-android/res/values-mr/strings.xml
+++ b/vlc-android/res/values-mr/strings.xml
@@ -139,8 +139,7 @@
     <string name="error_problem">क्षमस्व, VLC लोड करतेवेळी काही समस्या होती त्यामुळे तो बंद करावा लागला.</string>
     <string name="error_message_is">चूक संदेश असा आहे (कृपया डीबग करतेवेळी याचा उल्लेख करा):\n</string>
     <string name="encountered_error_title">प्लेबॅक मध्ये त्रुटी</string>
-    <string name="encountered_error_message">या मीडिया बरोबर VLC ला एक त्रुटी आली आहे.
-कृपया मीडिया लायब्ररी ताजी करून पुन्हा प्रयत्न करा.</string>
+    <string name="encountered_error_message">या मीडिया बरोबर VLC ला एक त्रुटी आली आहे.\nकृपया मीडिया लायब्ररी ताजी करून पुन्हा प्रयत्न करा.</string>
     <string name="invalid_location">%1$s हे स्थान प्ले केले जाऊ शकत नाही.</string>
 
     <string name="search">शोधा</string>
@@ -169,16 +168,13 @@
     <string name="about">VLC विषयी</string>
     <string name="about_text">Android™ साठी VLC ही VLC मीडिया प्लेयर या लोकप्रिय आणि उघड-स्त्रोत मीडिया प्लेयरची आवृत्ती आहे. ही Android™ आवृत्ती जवळपास सर्व फाईल्स आणि नेटवर्क स्ट्रीम वाचू शकते .</string>
     <string name="compiled_by">ही VLC आवृत्ती यांनी संकलित केली:</string>
-
     <string name="general_prefs_category">सर्वसामान्य</string>
     <string name="directories_summary">मीडिया लायब्ररी मध्ये समावेश करण्यासाठी निर्देशिका निवडा</string>
     <string name="add_custom_path">सानुकूल मार्ग प्रविष्ट करा</string>
     <string name="add_custom_path_description">स्कॅन करण्यासाठी अधिक सानुकूल निर्देशिका प्रविष्ट करा:</string>
     <string name="remove_custom_path">सानुकूल मार्ग काढून टाका</string>
     <string name="hardware_acceleration">हार्डवेअर अॅक्सलरेशन</string>
-    <string name="hardware_acceleration_summary">अक्षम: चांगले स्थिरता.
-डिकोड: कार्यप्रदर्शन सुधारू शकते.
-पूर्ण: पुढील कामगिरी सुधारू शकते.</string>
+    <string name="hardware_acceleration_summary">अक्षम: चांगले स्थिरता.\nडिकोड: कार्यप्रदर्शन सुधारू शकते.\nपूर्ण: पुढील कामगिरी सुधारू शकते.</string>
     <string name="hardware_acceleration_disabled">निष्क्रिय करा</string>
     <string name="hardware_acceleration_decoding">डिकोडिंग अॅक्सलरेशन</string>
     <string name="hardware_acceleration_full">पूर्ण अॅक्सलरेशन</string>
@@ -207,15 +203,12 @@
     <string name="audio_title_alignment_marquee">चिन्ह</string>
     <string name="enable_headset_detection">हेडसेट शोधा</string>
     <string name="enable_steal_remote_control">विशिष्ट हेडसेट दूरस्थ नियंत्रण</string>
-    <string name="enable_steal_remote_control_summary">अन्य अनुप्रयोगांकडून दूरस्थ नियंत्रण चोरून परस्परविरोध टाळा.
-हे HTC फोन वरील डायलिंग ऑन डबल क्लिक प्रतिबंधित करते.</string>
+    <string name="enable_steal_remote_control_summary">अन्य अनुप्रयोगांकडून दूरस्थ नियंत्रण चोरून परस्परविरोध टाळा. हे HTC फोन वरील डायलिंग ऑन डबल क्लिक प्रतिबंधित करते.</string>
     <string name="aout">ध्वनी आउटपुट</string>
     <string name="aout_summary">ध्वनी आउटपुटसाठी VLC जी पद्धत वापरते ती बदला.</string>
     <string name="performance_prefs_category">कार्यप्रदर्शन</string>
     <string name="chroma_format">चित्रफीत क्रोमा सक्त करा</string>
-    <string name="chroma_format_summary">RGB 32-bit: डीफॉल्ट क्रोमा
-RGB 16-bit: उत्तम कार्यप्रदर्शन पण कमी गुणवत्ता
-YUV: सर्वोत्तम कार्यप्रदर्शन पण सर्व साधनांवर काम करत नाही. फक्त Android 2.3 आणि नंतरचे.</string>
+    <string name="chroma_format_summary">RGB 32-bit: डीफॉल्ट क्रोमा\nRGB 16-bit: उत्तम कार्यप्रदर्शन पण कमी गुणवत्ता\nYUV: सर्वोत्तम कार्यप्रदर्शन पण सर्व साधनांवर काम करत नाही. फक्त Android 2.3 आणि नंतरचे.</string>
     <string name="deblocking">डीब्लॉकिंग फिल्टर सेटींग्स</string>
     <string name="deblocking_summary">डीब्लॉकिंग फिल्टर सेटींग्स बदला. चित्रफीत गुणवत्ता सुधारू शकते. फक्त प्रगत वापरकर्त्यांसाठी.</string>
     <string name="deblocking_always">पूर्ण डीब्लॉकिंग (सर्वात मंद)</string>

--- a/vlc-android/res/values-mr/strings.xml
+++ b/vlc-android/res/values-mr/strings.xml
@@ -258,4 +258,4 @@ YUV: सर्वोत्तम कार्यप्रदर्शन पण 
     <string name="drawer_open">नेव्हिगेशन ड्रॉवर उघडा</string>
     <string name="drawer_close">नेव्हिगेशन ड्रॉवर बंद करा</string>
     <string name="next">पुढील</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ms/strings.xml
+++ b/vlc-android/res/values-ms/strings.xml
@@ -241,6 +241,7 @@
     <string name="about_text">VLC untuk Android™ adalah port pemain media VLC, pemain media sumber terbuka yang popular. Versi Android™ boleh membaca kebanyakan fail dan strim rangkaian.</string>
     <string name="vlc_authors">dan Pengarang VLC.</string>
     <string name="compiled_by">Versi VLC ini dikompil oleh:</string>
+    <string name="feedback_forum">Forum maklumbalas</string>
 
     <!-- Preferences -->
     <string name="preferences">Tetapan</string>
@@ -673,4 +674,7 @@
     <string name="popup_force_legacy_summary">Guna tetingkap timbul boleh saiz semua Gambar-dalam-Gambar suai</string>
     <string name="device_default">Lalai peranti</string>
     <string name="track_number">%s trek</string>
+    <string name="jump_to">Lompat ke</string>
+    <string name="show_video_thumbnails_summary">Tunjuk lakaran kenit video dalam senarai</string>
+    <string name="show_video_thumbnails">Lakaran kenit video</string>
 </resources>

--- a/vlc-android/res/values-ms/strings.xml
+++ b/vlc-android/res/values-ms/strings.xml
@@ -211,6 +211,7 @@
     <string name="playback_speed_summary">Ingat kelajuan main balik yang anda tetapkan</string>
 
     <string name="play_button">Butang Main</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Petua pemain video:</string>
     <string name="seek">Jangkau</string>

--- a/vlc-android/res/values-my/strings.xml
+++ b/vlc-android/res/values-my/strings.xml
@@ -99,7 +99,6 @@
     <string name="about">အကြောင်း</string>
     <string name="about_text">စက်ရုပ်အတွက်ဗီအယ်စီမှာဗီအယ်စီမီဒီယာဖွင့်စက်၏ထွက်ပေါက်ဖြစ်၊ စက်ရုပ်ပံုစံမှာဖိုင်အများစနှင့်ကွန်ယက်စီးကြောင်းများကိုဖတ်ရှုနိုင်။</string>
     <string name="compiled_by">ယခုဗီအယ်စီပံုစံမှာအားဖြင့်စည်း:</string>
-
     <string name="directories_summary">မီဒီယာတိုက်တွင်ထည့်သွင်းရန်ဖိုင်လမ်းညွန်များရွေးချယ်</string>
     <string name="add_custom_path">စိတ်ကြိက်လမ်းကြောင်းထည့်</string>
     <string name="add_custom_path_description">ဖတ်ရှုရန်နောက်ထပ်စိတ်ကြိုက်ဖိုင်လမ်းညွှန်ထည့်:</string>

--- a/vlc-android/res/values-my/strings.xml
+++ b/vlc-android/res/values-my/strings.xml
@@ -137,4 +137,4 @@
     <string name="copy_to_clipboard">အောက်ခံကတ်ပြားသို့ကူးယူ</string>
     <string name="copied_to_clipboard">အောက်ခံကတ်ပြားသို့ကူးယူပြီး။</string>
     <string name="next">နောက်</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-nb/strings.xml
+++ b/vlc-android/res/values-nb/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Husk avspillingshastigheten du valgte</string>
 
     <string name="play_button">Avspillingsknapp</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Videospiller-tips:</string>
     <string name="seek">Søk</string>

--- a/vlc-android/res/values-nb/strings.xml
+++ b/vlc-android/res/values-nb/strings.xml
@@ -674,4 +674,4 @@
     <string name="add_to_new_playlist">Legg til i ny spilleliste</string>
     <string name="theme_follow_system_mode">Følg systemmodus</string>
     <string name="resume_card_message">Gjenoppta avspiling av %1$s?</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ne-rNP/strings.xml
+++ b/vlc-android/res/values-ne-rNP/strings.xml
@@ -188,6 +188,7 @@
 
     <string name="playback_history_title">बजाउने इतिहास</string>
     <string name="playback_history_summary">बजाइसकेका सबै मिडियाहरूलाइ इतिहास खण्डमा साँच्नुहोस्</string>
+
     <!-- Tips -->
     <string name="video_player_tips">भिडियो प्लेयर जानकारी:</string>
     <string name="subtitles">उपशिर्षकहरु</string>

--- a/vlc-android/res/values-ne-rNP/strings.xml
+++ b/vlc-android/res/values-ne-rNP/strings.xml
@@ -324,4 +324,4 @@
     <string name="browser_quick_access">छरितो पहुँच</string>
     <string name="browser_storages">भण्डारण</string>
     <string name="next">पछिल्लो</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-nl/strings.xml
+++ b/vlc-android/res/values-nl/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Ingestelde afspeelsnelheid onthouden</string>
 
     <string name="play_button">Afspeelknop</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Videospeler-tips:</string>
     <string name="seek">Zoeken</string>

--- a/vlc-android/res/values-nl/strings.xml
+++ b/vlc-android/res/values-nl/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">VLC voor Android™ is een port van VLC media player, de populaire open source mediaspeler. De Android™-versie kan de meeste bestanden en netwerkstreams lezen.</string>
     <string name="vlc_authors">en VLC-auteurs.</string>
     <string name="compiled_by">Deze versie van VLC werd gecompileerd door:</string>
+    <string name="feedback_forum">Feedback-forum</string>
 
     <!-- Preferences -->
     <string name="preferences">Instellingen</string>
@@ -680,4 +681,7 @@
     <string name="popup_force_legacy_summary">Aangepaste grootte-instelbare beeld-in-beeld popup gebruiken</string>
     <string name="device_default">Standaard van apparaat</string>
     <string name="track_number">%s tracks</string>
+    <string name="jump_to">Springen naar</string>
+    <string name="show_video_thumbnails_summary">Video-miniaturen weergeven in lijsten</string>
+    <string name="show_video_thumbnails">Video-miniaturen</string>
 </resources>

--- a/vlc-android/res/values-or/strings.xml
+++ b/vlc-android/res/values-or/strings.xml
@@ -110,7 +110,6 @@
     <string name="about">ବିଷୟରେ</string>
     <string name="about_text">Android™ ପାଇଁ VLC ହେଉଛି ଲୋକପ୍ରିୟ ମୁକ୍ତ ସ୍ରୋତ ମିଡିଆ ପ୍ଲେୟାର, VLC ମିଡିଆ ପ୍ଲେୟାରର ଏକ ଅନୁଭାଗ| Android™ ସଂସ୍କରଣ ପ୍ରାୟ ଫାଇଲ ଏବଂ ନେଟୱର୍କ ଷ୍ଟ୍ରିମ୍‌ ଗୁଡିକକୁ ଚଳାଇ ପାରିବ|</string>
     <string name="compiled_by">VLC ର ଏହି ସଂସ୍କରଣକୁ ସଙ୍କଳନ କରିଛନ୍ତି:</string>
-
     <string name="add_custom_path">ଇଚ୍ଛାରୂପୀ ପଥ ଯୋଗ କରନ୍ତୁ</string>
     <string name="remove_custom_path">ଇଚ୍ଛାରୂପୀ ପଥ ଅପସାରଣ କରନ୍ତୁ</string>
     <string name="hardware_acceleration_disabled">ନିଷ୍କ୍ରିୟ</string>

--- a/vlc-android/res/values-or/strings.xml
+++ b/vlc-android/res/values-or/strings.xml
@@ -139,4 +139,4 @@
     <string name="copy_to_clipboard">କ୍ଲିପବୋର୍ଡକୁ ନକଲ କରନ୍ତୁ</string>
     <string name="copied_to_clipboard">ଲଗ କ୍ଲିପବୋର୍ଡକୁ ନକଲ କରାଗଲା</string>
     <string name="next">ପରବର୍ତ୍ତୀ</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-pa/strings.xml
+++ b/vlc-android/res/values-pa/strings.xml
@@ -201,4 +201,4 @@
     <string name="restart_vlc">VLC ਮੁੜ-ਚਾਲੂ ਕਰੋ</string>
     <string name="send_log">ਲਾਗ ਭੇਜੋ</string>
     <string name="next">ਅੱਗੇ</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-pl/strings.xml
+++ b/vlc-android/res/values-pl/strings.xml
@@ -261,6 +261,7 @@
     <string name="about_text">VLC dla Androida™ jest portem VLC Media Player, popularnego odtwarzacza multimedialnego o otwartym kodzie źródłowym. Wersja systemu Android™ może odczytać większość plików i strumieni sieciowych.</string>
     <string name="vlc_authors">i autorzy VLC.</string>
     <string name="compiled_by">Ta wersja VLC została skompilowana przez:</string>
+    <string name="feedback_forum">Forum opinii</string>
 
     <!-- Preferences -->
     <string name="preferences">Ustawienia</string>
@@ -694,4 +695,6 @@
     <string name="device_default">Systemowy</string>
     <string name="track_number">%s utwory</string>
     <string name="jump_to">Przejdź do</string>
+    <string name="show_video_thumbnails_summary">Pokaż miniaturki wideo w listach</string>
+    <string name="show_video_thumbnails">Miniaturki wideo</string>
 </resources>

--- a/vlc-android/res/values-pl/strings.xml
+++ b/vlc-android/res/values-pl/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">Zapamiętaj ustawioną prędkość odtwarzania</string>
 
     <string name="play_button">Przycisk odtwarzania</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Porady odtwarzacza wideo:</string>
     <string name="seek">Szukaj</string>

--- a/vlc-android/res/values-pt-rBR/strings.xml
+++ b/vlc-android/res/values-pt-rBR/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Lembrar a velocidade de reprodução definida</string>
 
     <string name="play_button">Botão de Reprodução</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Dicas do reprodutor de vídeo:</string>
     <string name="seek">Buscar</string>

--- a/vlc-android/res/values-pt-rBR/strings.xml
+++ b/vlc-android/res/values-pt-rBR/strings.xml
@@ -247,6 +247,7 @@
     <string name="about_text">O VLC para Android™ é uma versão do Reprodutor de Mídias VLC, o popular reprodutor de mídias livre. A versão Android™ lê a maioria dos arquivos e fluxos de rede.</string>
     <string name="vlc_authors">e autores do VLC.</string>
     <string name="compiled_by">Esta versão do VLC foi compilada por:</string>
+    <string name="feedback_forum">Fórum de avaliação</string>
 
     <!-- Preferences -->
     <string name="preferences">Configurações</string>
@@ -680,4 +681,6 @@
     <string name="device_default">Dispositivo padrão</string>
     <string name="track_number">%s trilhas</string>
     <string name="jump_to">Ir para</string>
+    <string name="show_video_thumbnails_summary">Exibir miniaturas de vídeos em listas</string>
+    <string name="show_video_thumbnails">Miniaturas de vídeos</string>
 </resources>

--- a/vlc-android/res/values-pt/strings.xml
+++ b/vlc-android/res/values-pt/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Memorizar a velocidade de reprodução definida</string>
 
     <string name="play_button">Botão de Reproduzir</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Dicas do reprodutor de vídeo:</string>
     <string name="seek">Pesquisar</string>
@@ -680,4 +681,6 @@
     <string name="device_default">Predefinido do dispositivo</string>
     <string name="track_number">%s faixas</string>
     <string name="jump_to">Saltar para</string>
+    <string name="show_video_thumbnails_summary">Mostrar miniaturas dos vídeos nas listas</string>
+    <string name="show_video_thumbnails">Miniaturas dos vídeos</string>
 </resources>

--- a/vlc-android/res/values-ro/strings.xml
+++ b/vlc-android/res/values-ro/strings.xml
@@ -225,6 +225,7 @@
     <string name="playback_speed_summary">Rețineți viteza de redare aleasă</string>
 
     <string name="play_button">Buton de redare</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Sfaturi pentru redarea video:</string>
     <string name="seek">Căutare</string>

--- a/vlc-android/res/values-ro/strings.xml
+++ b/vlc-android/res/values-ro/strings.xml
@@ -643,4 +643,4 @@
     <string name="videos_folders_title">Afișare videoclipuri după dosare</string>
     <string name="video_save_remote_setting">Activați automat modul de control la distanță?</string>
     <string name="video_remote_enable">Comutați la modul de control la distanță</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ru/strings.xml
+++ b/vlc-android/res/values-ru/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">Запоминать последнюю установленную скорость воспроизведения</string>
 
     <string name="play_button">Кнопка воспроизведения</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Подсказки для видеоплеера:</string>
     <string name="seek">Переход</string>

--- a/vlc-android/res/values-ru/strings.xml
+++ b/vlc-android/res/values-ru/strings.xml
@@ -261,6 +261,7 @@
     <string name="about_text">VLC для Android™ - порт медиаплеера VLC (популярного плеера с открытым исходным кодом). Версия для Android™ может воспроизводить большинство файлов и сетевых потоков.</string>
     <string name="vlc_authors">и авторы VLC.</string>
     <string name="compiled_by">Эту версию VLC скомпилировал:</string>
+    <string name="feedback_forum">Форум</string>
 
     <!-- Preferences -->
     <string name="preferences">Настройки</string>
@@ -694,4 +695,6 @@
     <string name="device_default">По умолчанию для устройства</string>
     <string name="track_number">дорожек: %s </string>
     <string name="jump_to">Переход к</string>
+    <string name="show_video_thumbnails_summary">Показывать в списках видео в миниатюрах</string>
+    <string name="show_video_thumbnails">Видео в миниатюрах</string>
 </resources>

--- a/vlc-android/res/values-ru/strings.xml
+++ b/vlc-android/res/values-ru/strings.xml
@@ -132,6 +132,7 @@
     <string name="validation">Вы уверены?</string>
 
     <string name="cover_art">Обложка</string>
+    <string name="shuffle_all_title">Перемешать все</string>
     <string name="shuffle_title">Режим перемешивания</string>
     <string name="shuffle">Перемешивание выкл.</string>
     <string name="shuffle_on">Перемешивание вкл.</string>
@@ -288,6 +289,8 @@
     <string name="enable_black_theme_summary">Изменить цвета интерфейса для большего комфорта при низкой освещённости.</string>
     <string name="subtitle_text_encoding">Кодировка текста субтитров</string>
     <string name="daynight_title">Режим День/Ночь</string>
+    <string name="daynight_follow_system_title">В соответствии с режимом системы </string>
+    <string name="daynight_battery_title">В соответствии с режимом энергосбережения</string>
     <string name="daynight_summary">Автоматически переключаться в ночной режим в подходящее время</string>
 
     <string name="extra_prefs_category">Доп. настройки</string>
@@ -391,7 +394,7 @@
     <string name="casting_quality_low">Низкое</string>
     <string name="casting_quality_lowcpu">Самое низкое</string>
     <string name="cast_performance_warning">Для трансляции этого видео его нужно перекодировать. При перекодировании может использоваться вся доступная мощность и быстро разряжаться батарея.</string>
-    <string name="casting_connected_renderer">Подключено к экрану \'%1$s\'</string>
+    <string name="casting_connected_renderer">Подключено к воспроизводителю \'%1$s\'</string>
     <string name="artists_show_all_title">Показывать всех исполнителей</string>
     <string name="artists_show_all_summary">Показывать всех исполнителей в списке Исполнители, а не только исполнителей альбомов</string>
 
@@ -499,6 +502,7 @@
     <string name="directory_show_medialib">Показать в медиатеке</string>
     <string name="directory_hide_medialib">Убрать из медиатеки</string>
     <string name="playlist_save">Сохранить плейлист</string>
+    <string name="playlist_name_hint">Название плейлиста</string>
     <string name="go_to_chapter">Перейти к главе…</string>
     <string name="chapter">Глава</string>
     <string name="resume_from_position">Продолжить с последней позиции</string>
@@ -625,6 +629,8 @@
     <string name="audio_digital_title">Цифровой вывод звука (сквозной)</string>
     <string name="audio_task_cleared_title">Останавливаться при смахивании приложения</string>
     <string name="audio_task_cleared_summary">Прекращать воспроизведение, когда приложение смахивается</string>
+    <string name="audio_resume_card_title">Загружать последнюю карточку плейлиста</string>
+    <string name="audio_resume_card_summary">Показывать карточку, позволяющую возобновить воспроизведение аудио при запуске приложения</string>
     <string name="playback_rewind">Перемотка</string>
     <string name="playback_forward">Быстро вперёд</string>
     <string name="ml_wizard_title">Выбор медиатеки VLC</string>
@@ -664,6 +670,7 @@
     <string name="video_save_clone_mode">Автоматически включать режим клонирования?</string>
     <string name="video_remote_enable">Переключиться в режим удалённого управления</string>
     <string name="video_remote_disable">Дублировать экран</string>
+    <string name="removed_from_playlist_anonymous">Элементы, удалённые из плейлиста</string>
     <string name="welcome_title">Добро пожаловать в VLC!</string>
     <string name="welcome_subtitle">Бесплатный медиаплеер с открытым исходным кодом</string>
     <string name="permission_media">Для VLC требуется разрешение на чтение медиафайлов на вашем устройстве</string>
@@ -677,4 +684,14 @@
     <string name="onboarding_scan_customize">Я хочу выбрать, какие папки будет сканировать VLC</string>
     <string name="button_medialibrary_preferences">Открыть настройки медиатеки</string>
     <string name="light_theme">Светлая тема</string>
-    </resources>
+    <string name="add">Добавить</string>
+    <string name="add_to_new_playlist">Добавить в новый плейлист</string>
+    <string name="theme_follow_system_mode">В соответствии с режимом системы</string>
+    <string name="resume_card_message">Возобновить воспроизведение %1$s?</string>
+    <string name="misc">Разное</string>
+    <string name="popup_force_legacy_title">Использовать собственное окно PiP</string>
+    <string name="popup_force_legacy_summary">Использовать собственное изменяемое окно Picture-in-Picture</string>
+    <string name="device_default">По умолчанию для устройства</string>
+    <string name="track_number">дорожек: %s </string>
+    <string name="jump_to">Переход к</string>
+</resources>

--- a/vlc-android/res/values-sc/strings.xml
+++ b/vlc-android/res/values-sc/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Ammenta sa lestresa de riprodutzione impostada</string>
 
     <string name="play_button">Butone de riprodutzione</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Impòsitos de su leghidore de vìdeos:</string>
     <string name="seek">Positziona</string>

--- a/vlc-android/res/values-sc/strings.xml
+++ b/vlc-android/res/values-sc/strings.xml
@@ -679,4 +679,5 @@
     <string name="popup_force_legacy_summary">Imprea una ventanedda Picture-to-Picture personalizada chi podet èssere mudada de mannària</string>
     <string name="device_default">Predefinidu de su dispositivu</string>
     <string name="track_number">%s rastas</string>
+    <string name="jump_to">Brinca a</string>
 </resources>

--- a/vlc-android/res/values-sc/strings.xml
+++ b/vlc-android/res/values-sc/strings.xml
@@ -248,6 +248,7 @@
     <string name="about_text">VLC pro Android™ est una versione mòbile de su leghidore multimediale VLC, su populare leghidore multimediale a mitza aberta. Sa versione pro Android™ podet lèghere sa majoria de sos documentos e de sos flussos de retza.</string>
     <string name="vlc_authors">Autores de VLC.</string>
     <string name="compiled_by">Custa versione de VLC est compilata dae:</string>
+    <string name="feedback_forum">Forum de sinnalatzione</string>
 
     <!-- Preferences -->
     <string name="preferences">Impostatziones</string>
@@ -681,4 +682,6 @@
     <string name="device_default">Predefinidu de su dispositivu</string>
     <string name="track_number">%s rastas</string>
     <string name="jump_to">Brinca a</string>
+    <string name="show_video_thumbnails_summary">Ammustra sas miniaturas de sos vìdeos in sas listas</string>
+    <string name="show_video_thumbnails">Miniaturas de sos vìdeos</string>
 </resources>

--- a/vlc-android/res/values-si/strings.xml
+++ b/vlc-android/res/values-si/strings.xml
@@ -124,7 +124,6 @@
     <string name="about">මේ ගැන</string>
     <string name="about_text">ඇන්ඩ්‍රොයිඩ්™ සඳහා VLC යනු ජනප්‍රිය විවෘත මූලාශ්‍ර මාධ්‍ය වාදකයක් වන, VLC මාධ්‍ය වාදකයේ කවුළුවකි. ඇන්ඩ්‍රොයිඩ්™ අනුවාදය හට බොහෝ ගොනු සහ ජාල දහරාවන් කියවීමට හැක. සිංහල පරිවර්තනය පසිඳු කවින්ද විසිනි.</string>
     <string name="compiled_by">VLC හී මෙම අනුවාදය සම්පාදන කරන ලද්දේ:</string>
-
     <string name="general_prefs_category">ප්‍රධාන</string>
     <string name="directories_summary">මාධ්‍ය පුස්තකාලයේ අඩංගු විය යුතු ඩිරෙක්ටරියන් තෝරාගන්න</string>
     <string name="add_custom_path">රිසිකළ පෙතක් එක් කරන්න</string>

--- a/vlc-android/res/values-si/strings.xml
+++ b/vlc-android/res/values-si/strings.xml
@@ -193,4 +193,4 @@
     <string name="sending_log">ලඝු සටහන යවමින…</string>
 
     <string name="next">ඊළඟ</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-sk/strings.xml
+++ b/vlc-android/res/values-sk/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">Pamätať si vami nastavenú rýchlosť prehrávania</string>
 
     <string name="play_button">Tlačidlo Prehrať</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Tipy pre prehrávač videa:</string>
     <string name="seek">Vyhľadať</string>
@@ -261,6 +262,7 @@
     <string name="about_text">VLC for Android™ je portom programu VLC media player, populárneho open-source prehrávača médií. Verzia pre systém Android™ dokáže prečítať väčšinu súborov a sieťových streamov.</string>
     <string name="vlc_authors">a autori VLC</string>
     <string name="compiled_by">Túto verziu VLC skompiloval:</string>
+    <string name="feedback_forum">Fórum pre spätnú väzbu</string>
 
     <!-- Preferences -->
     <string name="preferences">Nastavenia</string>
@@ -694,4 +696,6 @@
     <string name="device_default">Predvolené zariadenie</string>
     <string name="track_number">stôp: %s</string>
     <string name="jump_to">Preskočiť na</string>
+    <string name="show_video_thumbnails_summary">Zobraziť náhľady videa v zoznamoch</string>
+    <string name="show_video_thumbnails">Náhľady videa</string>
 </resources>

--- a/vlc-android/res/values-sl/strings.xml
+++ b/vlc-android/res/values-sl/strings.xml
@@ -605,4 +605,4 @@
     <string name="download_the_selected">Prenesi izbrano</string>
     <string name="next">Naslednji</string>
     <string name="download">Prenesi</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-sl/strings.xml
+++ b/vlc-android/res/values-sl/strings.xml
@@ -224,6 +224,7 @@
     <string name="playback_speed_summary">Program si zapomni nastavljeno hitrost predvajanja</string>
 
     <string name="play_button">Gumb Predvajaj</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Namigi predvajalnika:</string>
     <string name="seek">Išči</string>

--- a/vlc-android/res/values-sq/strings.xml
+++ b/vlc-android/res/values-sq/strings.xml
@@ -311,4 +311,4 @@
     <string name="media_db_cleared">Database-i Media u pastrua!</string>
     <string name="debug_logs">Log-et e Debug</string>
     <string name="restart_vlc">Ristarto VLC</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-sr/strings.xml
+++ b/vlc-android/res/values-sr/strings.xml
@@ -234,4 +234,4 @@
     <string name="sending_log">Шаљем извештај…</string>
 
     <string name="next">Следеће</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-sr/strings.xml
+++ b/vlc-android/res/values-sr/strings.xml
@@ -156,7 +156,6 @@
     <string name="about">О апликацији</string>
     <string name="about_text">VLC за Android је порт VLC Media Player-а, популарног медијског плејера отвореног кода. Верзија за Android може да репродукује многе датотеке и мрежне токове.</string>
     <string name="compiled_by">Ову верзију VLC-а је компилирао:</string>
-
     <string name="general_prefs_category">Опште</string>
     <string name="directories_summary">Изаберите фасцикле за медијску библиотеку</string>
     <string name="add_custom_path">Додај прилагођену путању</string>

--- a/vlc-android/res/values-sv/strings.xml
+++ b/vlc-android/res/values-sv/strings.xml
@@ -247,6 +247,7 @@
     <string name="about_text">VLC för Android™ är en portering av VLC media player, den populära mediaspelaren med öppen källkod. Android™-versionen kan läsa de flesta filerna och nätverksströmmarna.</string>
     <string name="vlc_authors">och VLC:s upphovsmän.</string>
     <string name="compiled_by">Denna version av VLC är kompilerad av:</string>
+    <string name="feedback_forum">Återkopplingsforum</string>
 
     <!-- Preferences -->
     <string name="preferences">Inställningar</string>
@@ -680,4 +681,6 @@
     <string name="device_default">Enhetsstandard</string>
     <string name="track_number">%s spår</string>
     <string name="jump_to">Hoppa till</string>
+    <string name="show_video_thumbnails_summary">Visa videominiatyrer i listor</string>
+    <string name="show_video_thumbnails">Videominiatyrer</string>
 </resources>

--- a/vlc-android/res/values-sv/strings.xml
+++ b/vlc-android/res/values-sv/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Kom ihåg uppspelningshastigheten du angav</string>
 
     <string name="play_button">Uppspelningsknapp</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Tips för videospelaren:</string>
     <string name="seek">Snabbspola</string>

--- a/vlc-android/res/values-ta/strings.xml
+++ b/vlc-android/res/values-ta/strings.xml
@@ -196,6 +196,7 @@
 
     <string name="playback_history_title">இயக்க வரலாறு</string>
     <string name="playback_speed_title">இயக்க வேகத்தை சேமிக்க</string>
+
     <!-- Tips -->
     <string name="video_player_tips">ஊடக இயக்கி உதவிக்குறிப்புகள்:</string>
     <string name="seek">நாடுங்கள்</string>
@@ -368,6 +369,7 @@
     <string name="chapter">அத்தியாயம்</string>
     <string name="directory_empty">அடைவு வெறுமையாக உள்ளது</string>
     <string name="medialibrary">ஊடக நூலகம்</string>
+
     <!-- Accessibility -->
     <string name="more_actions">மேலும் செயல்கள்</string>
     <string name="move">நகர்த்து</string>
@@ -378,6 +380,7 @@
     <string name="music_now_playing">இப்போ ஒடுவது</string>
 
     <string name="exit_app">VLC-ஐ நிறுத்து</string>
+
     <!-- Plugins -->
     <string name="plugins">நிரல்கள்</string>
     <string name="download_on_device">பதிவிறக்கு</string>

--- a/vlc-android/res/values-ta/strings.xml
+++ b/vlc-android/res/values-ta/strings.xml
@@ -406,4 +406,4 @@
     <string name="dialog_sd_wizard">காண்பி</string>
     <string name="renderers_disconnect">துண்டி</string>
     <string name="next">அடுத்து</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-te/strings.xml
+++ b/vlc-android/res/values-te/strings.xml
@@ -66,7 +66,6 @@
     <string name="about">గురించి</string>
     <string name="about_text">ఆండ్రాయిడ్™ కోసం వియల్సీ అనేది అత్యంత ప్రజాదరణ పొందిన ఒపెన్ సోర్సు మాధ్యమ ప్రదర్శకం అయిన వియల్సీ మాధ్యమ ప్రదర్శకం నుండి రూపొందించబడింది. ఆండ్రాయిడ్™ సంస్కరణ చాలా దస్త్రాలను మరియు నెట్వర్క్ ప్రవాహాలను చదవగలదు.</string>
     <string name="compiled_by">ఈ వీయల్సీ యొక్క సంస్కరణను సంకలనం చేసినవారు:</string>
-
     <string name="automatic">స్వయంచాలకం</string>
     <string name="enable_headset_detection">హెడ్‌సెట్‌ను కనిపెట్టు</string>
     <string name="aout">ఆడియో అవుట్‌పుట్</string>

--- a/vlc-android/res/values-te/strings.xml
+++ b/vlc-android/res/values-te/strings.xml
@@ -76,4 +76,4 @@
     <string name="enable_verbose_mode">వెర్బోస్</string>
     <string name="enable_verbose_mode_summary">వెర్బోసిటీని పెంచు (logcat)</string>
     <string name="next">తరువాత</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-th/strings.xml
+++ b/vlc-android/res/values-th/strings.xml
@@ -551,4 +551,4 @@
     <string name="dialog_sd_wizard">แสดงวิธีการ</string>
     <string name="renderers_disconnect">ยกเลิกการเชื่อมต่อ</string>
     <string name="next">ถัดไป</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-tr/strings.xml
+++ b/vlc-android/res/values-tr/strings.xml
@@ -20,8 +20,8 @@
     <string name="sortby_date_desc">Tarih (azalan)</string>
     <string name="sortby_last_modified_date">Son eklenen</string>
     <string name="sortby_last_modified_date_desc">Son eklenen (azalan)</string>
-    <string name="sortby_number">İz numarası</string>
-    <string name="sortby_number_desc">İz numarası (azalan)</string>
+    <string name="sortby_number">Kayıt numarası</string>
+    <string name="sortby_number_desc">Kayıt numarası (azalan)</string>
     <string name="searchable_hint">Arama…</string>
     <string name="history">Geçmiş</string>
 
@@ -66,7 +66,7 @@
     <string name="unknown_artist">Bilinmeyen Sanatçı</string>
     <string name="unknown_album">Bilinmeyen Albüm</string>
     <string name="unknown_genre">Bilinmeyen Tür</string>
-    <string name="unknown_number">Bilinmeyen iz numarası</string>
+    <string name="unknown_number">Bilinmeyen kayıt numarası</string>
     <string name="songs">Parçalar</string>
     <plurals name="songs_quantity">
         <item quantity="one">1 parça</item>
@@ -75,7 +75,7 @@
 
     <string name="artists">Sanatçılar</string>
     <string name="albums">Albümler</string>
-    <string name="tracks">İzler</string>
+    <string name="tracks">Kayıtlar</string>
 
     <plurals name="albums_quantity">
         <item quantity="one">1 albüm</item>
@@ -142,10 +142,10 @@
     <string name="thumbnail">Küçük görsel</string>
     <string name="unseekable_stream">Arama yapılamayan akış</string>
     <string name="refresh">Yenile</string>
-    <string name="track_audio">Ses izi</string>
-    <string name="track_video">Görüntü izi</string>
-    <string name="track_text">Alt yazı izi</string>
-    <string name="track_unknown">Bilinmeyen iz</string>
+    <string name="track_audio">Ses kaydı</string>
+    <string name="track_video">Görüntü kaydı</string>
+    <string name="track_text">Alt yazı kaydı</string>
+    <string name="track_unknown">Bilinmeyen kayıt</string>
     <string name="track_bitrate_info">Bit hızı: %1$s/s\n</string>
     <string name="track_codec_info">Kodlayıcı/Çözücü: %1$s\n</string>
     <string name="track_language_info">Dil: %1$s\n</string>
@@ -223,7 +223,7 @@
     <string name="video_player_tips">Görüntü oynatıcı ipuçları:</string>
     <string name="seek">Arama</string>
     <string name="subtitles">Alt yazılar</string>
-    <string name="audio_sub">Ses izleri\nve alt yazılar</string>
+    <string name="audio_sub">Ses kayıtları\nve alt yazılar</string>
     <string name="resize">Boyutlandır</string>
     <string name="options">Ayarlar</string>
     <string name="lock">Kilitle</string>
@@ -362,7 +362,7 @@
     <string name="enable_headset_detection">Kulaklık algılansın</string>
     <string name="enable_headset_detection_summary">Kulaklığın takıldığı ve çıkarıldığı algılansın</string>
     <string name="enable_headset_actions_title">Uzaktan Denetim Kısayolları</string>
-    <string name="enable_headset_actions_summary">\'Oynat\' üzerine çift dokunarak sonraki ize, uzun basarak önceki ize geçebilirsiniz</string>
+    <string name="enable_headset_actions_summary">\'Oynat\' üzerine çift dokunarak sonraki kayıda, uzun basarak önceki kayıda geçebilirsiniz</string>
     <string name="enable_play_on_headset_insertion">Kulaklık takıldığında sürdürülsün</string>
     <string name="enable_play_on_headset_insertion_summary">Çıkartıldığında duraklatılsın</string>
     <string name="enable_steal_remote_control">Kumanda yalnız kulaklık için kullanılsın</string>
@@ -629,7 +629,7 @@
     <string name="otg_device_title">Dokun yedekle aygıtı</string>
     <string name="browser">Tarayıcı</string>
     <string name="ab_repeat">A-B Yineleme</string>
-    <string name="stop_after_this">Bu izden sonra dur</string>
+    <string name="stop_after_this">Bu kayıttan sonra dur</string>
     <string name="time_category_new">Yeni ortam</string>
     <string name="time_category_current_month">Bu ay</string>
     <string name="time_category_current_year">Bu yıl</string>
@@ -646,10 +646,10 @@
     <string name="download_the_selected">Seçimi indir</string>
     <string name="next">Sonraki</string>
     <string name="download">İndir</string>
-    <string name="ctx_player_video_track">Görüntü izini seçin</string>
-    <string name="ctx_player_audio_track">Ses izi</string>
-    <string name="ctx_player_subs_track">Alt yazı izi</string>
-    <string name="ctx_player_tracks_title">Ortam izleri</string>
+    <string name="ctx_player_video_track">Görüntü kaydını seçin</string>
+    <string name="ctx_player_audio_track">Ses kaydı</string>
+    <string name="ctx_player_subs_track">Alt yazı kaydı</string>
+    <string name="ctx_player_tracks_title">Ortam kayıtları</string>
     <string name="ctx_pip_title">Açılan pencerede oynatıcı</string>
     <string name="device_dialog_title">Bir dış aygıt takıldı</string>
     <string name="device_dialog_message">TV kutunuza yeni bir depolama aygıtı bağladınız. Bu aygıtın VLC ile açılmasını ister misiniz?</string>
@@ -680,7 +680,7 @@
     <string name="popup_force_legacy_title">Görsel içinde görsel penceresi kullanılsın</string>
     <string name="popup_force_legacy_summary">Boyutu ayarlanabilir görsel içinde görsel penceresi kullanılsın</string>
     <string name="device_default">Aygıt varsayılanları</string>
-    <string name="track_number">%s iz</string>
+    <string name="track_number">%s kayıt</string>
     <string name="jump_to">Şuraya atla</string>
     <string name="show_video_thumbnails_summary">Bu seçenek etkinleştirildiğinde, listede görüntü küçük görselleri görüntülenir</string>
     <string name="show_video_thumbnails">Görüntü küçük görselleri</string>

--- a/vlc-android/res/values-tr/strings.xml
+++ b/vlc-android/res/values-tr/strings.xml
@@ -218,6 +218,7 @@
     <string name="playback_speed_summary">Ayarlanan oynatma hızı hatırlansın</string>
 
     <string name="play_button">Oynatma Düğmesi</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Görüntü oynatıcı ipuçları:</string>
     <string name="seek">Arama</string>

--- a/vlc-android/res/values-tr/strings.xml
+++ b/vlc-android/res/values-tr/strings.xml
@@ -247,6 +247,7 @@
     <string name="about_text">Android™ için VLC, çok kullanılan açık kaynaklı VLC ortam oynatıcının bir parçasıdır. Android™ sürümü çoğu dosya ve ağ akışlarını okuyabilir.</string>
     <string name="vlc_authors">ve VLC Geliştiricileri.</string>
     <string name="compiled_by">Bu VLC sürümü şu kişiler tarafından oluşturulmuştur:</string>
+    <string name="feedback_forum">Geri bildirim forumu</string>
 
     <!-- Preferences -->
     <string name="preferences">Ayarlar</string>
@@ -680,4 +681,6 @@
     <string name="device_default">Aygıt varsayılanları</string>
     <string name="track_number">%s iz</string>
     <string name="jump_to">Şuraya atla</string>
+    <string name="show_video_thumbnails_summary">Bu seçenek etkinleştirildiğinde, listede görüntü küçük görselleri görüntülenir</string>
+    <string name="show_video_thumbnails">Görüntü küçük görselleri</string>
 </resources>

--- a/vlc-android/res/values-tt/strings.xml
+++ b/vlc-android/res/values-tt/strings.xml
@@ -531,4 +531,4 @@
     <string name="sdcard_permission_dialog_message">VLC бу файлны язуга рөхсәтсез бетерә алмый.\nSD-картагызга күчегез һәм \"Сайларга\" төймәсенә басыгыз.\nБәлки, сезгә баштан өске уң яктагы \"SD-картаны күрсәтергә\" төймәсенә басырга кирәк булыр.</string>
     <string name="dialog_sd_wizard">Күрсәтергә</string>
     <string name="next">&amp;Чираттагы</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ug/strings.xml
+++ b/vlc-android/res/values-ug/strings.xml
@@ -200,4 +200,4 @@
     <string name="drawer_open">يولباشچى تىزىملىكىنى ئاچ</string>
     <string name="drawer_close">يولباشچى تىزىملىكىنى تاقا</string>
     <string name="next">كېيىنكى</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ug/strings.xml
+++ b/vlc-android/res/values-ug/strings.xml
@@ -131,7 +131,6 @@
     <string name="about">ھەققىدە</string>
     <string name="about_text">VLC for Android™ ئالقىشقا ئېرىشكەن كودى ئوچۇق ۋاستە چالغۇچ VLC media player نىڭ يۆتكەلگەن نەشرى. Android™ نەشرى كۆپ قىسىم ھۆججەتلەر ۋە تور ئېقىم ۋاستىلىرىنى ئوقۇيالايدۇ.</string>
     <string name="compiled_by">بۇ نەشرىدىكى VLC نى ھاسىللىغۇچى</string>
-
     <string name="general_prefs_category">ئادەتتىكى</string>
     <string name="directories_summary">ۋاستە ئامبىرى ئۆز ئىچىگە ئالىدىغان مۇندەرىجىنى تاللاڭ</string>
     <string name="add_custom_path">ئىختىيارىي يول قوش</string>

--- a/vlc-android/res/values-uk/strings.xml
+++ b/vlc-android/res/values-uk/strings.xml
@@ -232,6 +232,7 @@
     <string name="playback_speed_summary">Запам\'ятати швидкість відтворення, задану вами</string>
 
     <string name="play_button">Кнопка Відтворити</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Поради для відеопрогравача:</string>
     <string name="seek">Шукати</string>

--- a/vlc-android/res/values-uk/strings.xml
+++ b/vlc-android/res/values-uk/strings.xml
@@ -261,6 +261,7 @@
     <string name="about_text">VLC для Android™ ­— це порт медіаплеєра VLC, відомого плеєра з відкритим вихідним кодом. Версія для Android™ може відтворювати більшість файлів і мережевих потоків.</string>
     <string name="vlc_authors">та автори VLC.</string>
     <string name="compiled_by">Цю версію VLC скомпільовано:</string>
+    <string name="feedback_forum">Форум для відгуків</string>
 
     <!-- Preferences -->
     <string name="preferences">Параметри</string>
@@ -694,4 +695,6 @@
     <string name="device_default">Типовий пристрій</string>
     <string name="track_number">%s доріжок</string>
     <string name="jump_to">Перейти до</string>
+    <string name="show_video_thumbnails_summary">Показувати  ескізи відео у списках</string>
+    <string name="show_video_thumbnails">Ескізи відео</string>
 </resources>

--- a/vlc-android/res/values-ur/strings.xml
+++ b/vlc-android/res/values-ur/strings.xml
@@ -156,4 +156,4 @@
     <string name="copy_to_clipboard">کِلپ بورڈ پر کاپی کریں</string>
     <string name="copied_to_clipboard">کلپ بورڈ میں لاگ میں نقل کردیا گيا ھے.</string>
     <string name="next">اگلا</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-ur/strings.xml
+++ b/vlc-android/res/values-ur/strings.xml
@@ -108,7 +108,6 @@
     <string name="about">کے بارے میں</string>
     <string name="about_text">اينذرائڈ کے ليے وى ـ ايل ـ سى ـ میڈیا پلیئر وى ـ ايل ـ سى ـ میڈیا پلیئر پر مبنى ہے،  جو کہ ايک مقبول اوپن سورس میڈیا پلیئر ہے. اينذرائڈ والا ورژن بہت سى فائلوں اور نیٹ ورک اسٹریمز کو پڑھ سکتا ہے.</string>
     <string name="compiled_by">وى ـ ايل ـ سى ـ کا يہ ورژن تیار کرنے والے کا نام:</string>
-
     <string name="directories_summary">ميڈيا لائبريری ميں شامل کرنے کے ليے فولڈرزمنتخب کريں</string>
     <string name="add_custom_path">اپنی مرضی کے مطابق (کسٹم) جگہ (پاتھ) ڈاليں</string>
     <string name="add_custom_path_description">اپنی مرضی کے مطابق مذيد فولڈر سکين کرنے کيليے ڈاليں:</string>

--- a/vlc-android/res/values-uz/strings.xml
+++ b/vlc-android/res/values-uz/strings.xml
@@ -234,4 +234,4 @@ Media kutubxonasini yangilashga harakat qiling.</string>
     <string name="drawer_open">Navigatsiya tortmasini ochish</string>
     <string name="drawer_close">Navigatsiya tortmasini yopish</string>
     <string name="next">Keyingi</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-uz/strings.xml
+++ b/vlc-android/res/values-uz/strings.xml
@@ -121,8 +121,7 @@
     <string name="error_problem">Kechirasiz, Android uchun VLC dasturini yuklashda muammo yuz berdi, shuning uchun uni yopishga to‘g‘ri keldi.</string>
     <string name="error_message_is">Xatolik haqida xabar (nosozlikni tuzatish uchun kerak bo‘ladi):\n</string>
     <string name="encountered_error_title">Ijro etishda xato</string>
-    <string name="encountered_error_message">VLC`da ushbu media bilan muammo boʻldi.
-Media kutubxonasini yangilashga harakat qiling.</string>
+    <string name="encountered_error_message">VLC`da ushbu media bilan muammo boʻldi.\nMedia kutubxonasini yangilashga harakat qiling.</string>
     <string name="invalid_location">%1$s manzilidagi media faylni ijro etib bo‘lmaydi.</string>
 
     <string name="search">Izlash</string>
@@ -151,7 +150,6 @@ Media kutubxonasini yangilashga harakat qiling.</string>
     <string name="about">Dastur haqida</string>
     <string name="about_text">Android™ uchun VLC – VLC media pleyerning (ochiq kodli mashhur pleyer) port qilingan versiyasi hisoblanadi. Uning Android™ versyasi ko‘plab fayl turlari va tarmoqli oqim rejimida uzatiladigan videolarni o‘qiy oladi.</string>
     <string name="compiled_by">VLC dasturining ushbu versiyasi ushbu inson tomonidan kompilatsiya qilingan:</string>
-
     <string name="general_prefs_category">Umumiy</string>
     <string name="directories_summary">Media kutubxonaga qoʻshish uchun direktoriyalarni tanlang</string>
     <string name="add_custom_path">Boshqa yo‘lni qo‘shish</string>

--- a/vlc-android/res/values-vi/strings.xml
+++ b/vlc-android/res/values-vi/strings.xml
@@ -157,4 +157,4 @@
     <string name="copy_to_clipboard">Lưu vào bộ nhớ ảo</string>
     <string name="copied_to_clipboard">Đã sao chép Nhật Ký vào bộ nhớ ảo.</string>
     <string name="next">Tiếp</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-vi/strings.xml
+++ b/vlc-android/res/values-vi/strings.xml
@@ -102,6 +102,7 @@
     <string name="error_not_compatible">Thật đáng tiếc, phiên bản VLC dành cho Android™ này hiện không hỗ trợ đối với thiết bị của bạn.</string>
     <string name="error_problem">Thật đáng tiếc, VLC dành cho Android đã gặp phải trục trặc trong quá trình khởi động và buộc phải đóng lại.</string>
     <string name="encountered_error_title">Lỗi xảy ra khi phát lại</string>
+
     <!-- About -->
     <string name="app_name_full">VLC dành cho</string>
     <string name="licence">Bản quyền</string>
@@ -109,7 +110,6 @@
     <string name="about">Thông tin</string>
     <string name="about_text">VLC dành cho  Android™ là một chương trình nằm trong dự án VLC Media Player, vốn được biết tới với đại đa số người dùng trên khắp thế giới vì tính miễn phí, mã nguồn mở và đầy tiện dụng của mình. Phiên bản dành cho Android™ có thể xem/đọc được hầu hết các định dạng file/tập tin lẫn tương tác với luồng dữ liệu trực tuyến. Bản dịch Việt Ngữ được thực hiện bởi Phan Anh.</string>
     <string name="compiled_by">Phiên bản VLC này được biên dịch bởi:</string>
-
     <string name="directories_summary">Chọn thư mục để chứa Thư Viện Media</string>
     <string name="add_custom_path">Thêm vào đường dẫn tự chọn</string>
     <string name="add_custom_path_description">Thêm vào thư mục do bạn chỉ định để quét:</string>

--- a/vlc-android/res/values-wa/strings.xml
+++ b/vlc-android/res/values-wa/strings.xml
@@ -107,4 +107,4 @@
     <string name="enable_verbose_mode">Badjawe</string>
     <string name="enable_verbose_mode_summary">Håssî l\' tchafiaedje (logcat)</string>
     <string name="next">Shuvant</string>
-    </resources>
+</resources>

--- a/vlc-android/res/values-wa/strings.xml
+++ b/vlc-android/res/values-wa/strings.xml
@@ -89,7 +89,6 @@
     <string name="about">Åd fwait</string>
     <string name="about_text">VLC po Android™ est on pôrt do djouweu d\' media VLC, li djouweu d\' media libe et spårdou. Li modêye Android™ pout lére li plupårt des fitchîs et des floûs rantoele.</string>
     <string name="compiled_by">Ci modêye di VLC est copilêye pa:</string>
-
     <string name="add_custom_path">Radjouter on tchimin da vosse</string>
     <string name="remove_custom_path">Oister li tchimin da vosse</string>
     <string name="automatic">Otomatike</string>

--- a/vlc-android/res/values-zh-rCN/strings.xml
+++ b/vlc-android/res/values-zh-rCN/strings.xml
@@ -211,6 +211,7 @@
     <string name="playback_speed_summary">记住您所设置的回放速度</string>
 
     <string name="play_button">播放按钮</string>
+
     <!-- Tips -->
     <string name="video_player_tips">视频播放器小提示:</string>
     <string name="seek">定位</string>
@@ -240,6 +241,7 @@
     <string name="about_text">VLC for Android™ 是广受欢迎的开源媒体播放器 VLC media player 的移植版本。Android™ 版本可以读取大多数文件及网络流。</string>
     <string name="vlc_authors">及 VLC 全体作者。</string>
     <string name="compiled_by">此版本 VLC 的编译者为:</string>
+    <string name="feedback_forum">反馈论坛</string>
 
     <!-- Preferences -->
     <string name="preferences">设置</string>
@@ -673,4 +675,6 @@
     <string name="device_default">设备默认</string>
     <string name="track_number">%s 条轨道</string>
     <string name="jump_to">跳转到</string>
+    <string name="show_video_thumbnails_summary">在列表中显示视频缩略图</string>
+    <string name="show_video_thumbnails">视频缩略图</string>
 </resources>

--- a/vlc-android/res/values-zh-rTW/strings.xml
+++ b/vlc-android/res/values-zh-rTW/strings.xml
@@ -211,6 +211,7 @@
     <string name="playback_speed_summary">記住您設定的播放速度</string>
 
     <string name="play_button">播放按鈕</string>
+
     <!-- Tips -->
     <string name="video_player_tips">影片播放器秘訣：</string>
     <string name="seek">尋找</string>
@@ -240,6 +241,7 @@
     <string name="about_text">VLC for Android™ 移植自VLC媒體播放器，是相當受歡迎的開源媒體播放器。此Android™版本可以讀取大部分的媒體檔案和網路串流。</string>
     <string name="vlc_authors">和 VLC 作者。</string>
     <string name="compiled_by">此版本 VLC 由以下人員編譯：</string>
+    <string name="feedback_forum">回饋討論區</string>
 
     <!-- Preferences -->
     <string name="preferences">設定</string>
@@ -673,4 +675,6 @@
     <string name="device_default">裝置預設值</string>
     <string name="track_number">%s 軌道</string>
     <string name="jump_to">跳至</string>
+    <string name="show_video_thumbnails_summary">在清單中顯示影片縮圖</string>
+    <string name="show_video_thumbnails">影片縮圖</string>
 </resources>

--- a/vlc-android/res/values/strings.xml
+++ b/vlc-android/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="playback_speed_summary">Remember the playback speed you set</string>
 
     <string name="play_button">Play Button</string>
+
     <!-- Tips -->
     <string name="video_player_tips">Video player tips:</string>
     <string name="seek">Seek</string>


### PR DESCRIPTION
Removed a space gap at the last tag `</resources>` in all translations.
This is needed to avoid file diffs if the last string isn't translated yet.

And some translations of the last string.