### PR TITLE
Avoid TextureView attach crash

### DIFF
--- a/libvlc/src/org/videolan/libvlc/AWindow.java
+++ b/libvlc/src/org/videolan/libvlc/AWindow.java
@@ -94,7 +94,8 @@ public class AWindow implements IVLCVout {
         @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
         private void attachTextureView() {
             mTextureView.setSurfaceTextureListener(mSurfaceTextureListener);
-            setSurface(new Surface(mTextureView.getSurfaceTexture()));
+            if(mTextureView.getSurfaceTexture()!=null)
+                setSurface(new Surface(mTextureView.getSurfaceTexture()));
         }
 
         private void attachSurface() {


### PR DESCRIPTION
Avoid crash since mTextureView may not be ready and once it is ready the surface will be set in the mSurfaceTextureListener.