### PR TITLE
Add option to auto rewind 5 seconds after pause

### DIFF
--- a/vlc-android/res/values/strings.xml
+++ b/vlc-android/res/values/strings.xml
@@ -450,6 +450,8 @@
     <string name="network_caching_summary">The amount of time to buffer network media (in ms). Does not work with hardware decoding. Leave blank to reset.</string>
     <string name="resume_playback_title">Resume playback after a call</string>
     <string name="resume_playback_summary">Stay in pause otherwise</string>
+    <string name="auto_rewind_a_bit_after_pause_title">Auto rewind 5 seconds after pause</string>
+    <string name="auto_rewind_a_bit_after_pause_summary">Useful when listen audio book or podcast</string>
     <string name="blurred_cover_background_title">Blurred cover background</string>
     <string name="blurred_cover_background_summary">Blurred cover in audio player background</string>
     <string name="network_caching_popup">This value must be between 0 and 6000 ms</string>

--- a/vlc-android/res/xml/preferences_ui.xml
+++ b/vlc-android/res/xml/preferences_ui.xml
@@ -34,6 +34,12 @@
         android:title="@string/resume_playback_title" />
 
     <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="auto_rewind_a_bit_after_pause"
+        android:summary="@string/auto_rewind_a_bit_after_pause_summary"
+        android:title="@string/auto_rewind_a_bit_after_pause_title" />
+
+    <CheckBoxPreference
         android:defaultValue="true"
         android:key="browser_show_all_files"
         android:summary="@string/browser_show_all_summary"

--- a/vlc-android/src/org/videolan/vlc/media/PlayerController.kt
+++ b/vlc-android/src/org/videolan/vlc/media/PlayerController.kt
@@ -55,6 +55,10 @@ class PlayerController(val context: Context) : IVLCVout.Callback, MediaPlayer.Ev
     fun pause(): Boolean {
         if (isPlaying() && mediaplayer.hasMedia() && pausable) {
             mediaplayer.pause()
+            if (settings.getBoolean(AUTO_REWIND_A_BIT_AFTER_PAUSE, false)){
+                val autoRewindDurationInMs = 5000
+                setTime(getCurrentTime() - autoRewindDurationInMs)
+            }
             return true
         }
         return false

--- a/vlc-android/src/org/videolan/vlc/util/Settings.kt
+++ b/vlc-android/src/org/videolan/vlc/util/Settings.kt
@@ -71,4 +71,5 @@ const val RESULT_UPDATE_ARTISTS = Activity.RESULT_FIRST_USER + 5
 
 const val PLAYBACK_HISTORY = "playback_history"
 const val RESUME_PLAYBACK = "resume_playback"
+const val AUTO_REWIND_A_BIT_AFTER_PAUSE = "auto_rewind_a_bit_after_pause"
 const val AUDIO_DUCKING = "audio_ducking"


### PR DESCRIPTION
I use 'play as audio' mode of vlc-android a lot for my English listening practice when commuting. This feature comes in handy in that I can simply press the pause/resume button on my headphone to re-listen the last segment if I did not catch it. Think it might be useful for other users as well.