### PR TITLE
Fix Playlist Random play bug

### DIFF
--- a/application/vlc-android/src/org/videolan/vlc/media/PlaylistManager.kt
+++ b/application/vlc-android/src/org/videolan/vlc/media/PlaylistManager.kt
@@ -555,10 +555,9 @@ class PlaylistManager(val service: PlaybackService) : MediaWrapperList.EventList
                         return
                     } else {
                         previous.clear()
-                        random = Random(System.currentTimeMillis())
+                        random.setSeed(System.currentTimeMillis())
                     }
                 }
-                random = Random(System.currentTimeMillis())
                 // Find a new index not in previous.
                 do {
                     nextIndex = random.nextInt(size)
@@ -613,7 +612,18 @@ class PlaylistManager(val service: PlaybackService) : MediaWrapperList.EventList
                     }
                 }
             }
-            ret = index
+            if (shuffling && ml.count > 1 && !previous.isEmpty()) {
+                for (i in 0 until previous.size) {
+                    if (previous[i] > index) {
+                        previous[i] += ml.count - 1
+                    }
+                }
+            }
+            if (shuffling && ml.count > 1) {
+                ret = index + random.nextInt(ml.count)
+            } else {
+                ret = index
+            }
         }
         ml?.release()
         return ret


### PR DESCRIPTION
Unnecessary instance creation
```diff
@@ -558,1 +558,1 @@
-                        random = Random(System.currentTimeMillis())
+                        random.setSeed(System.currentTimeMillis())
```


Unnecessary code
```diff
@@ -561,1 @@
-                random = Random(System.currentTimeMillis())
```

Fix previous indexes when expand list
```diff
@@ +615,7 @@
+            if (shuffling && ml.count > 1 && !previous.isEmpty()) {
+                for (i in 0 until previous.size) {
+                    if (previous[i] > index) {
+                        previous[i] += ml.count - 1
+                    }
+                }
+            }
```


alltimes play the top when expand list
```diff
@@ -616,1 +622,5 @@
-            ret = index
+            if (shuffling && ml.count > 1) {
+                ret = index + random.nextInt(ml.count)
+            } else {
+                ret = index
+            }
```