### PR TITLE
Enable explicit FTP over SSL/TLS support (FTPES)

### DIFF
--- a/application/resources/src/main/res/values/arrays.xml
+++ b/application/resources/src/main/res/values/arrays.xml
@@ -3,6 +3,7 @@
     <string-array name="server_protocols">
         <item>FTP</item>
         <item>FTPS</item>
+        <item>FTPES</item>
         <item>SFTP</item>
         <!--<item>HTTP</item>-->
         <!--<item>HTTPS</item>-->

--- a/application/vlc-android/AndroidManifest.xml
+++ b/application/vlc-android/AndroidManifest.xml
@@ -158,6 +158,7 @@
                 <data android:scheme="file"/>
                 <data android:scheme="ftp"/>
                 <data android:scheme="ftps"/>
+                <data android:scheme="ftpes"/>
                 <data android:scheme="sftp"/>
                 <data android:scheme="content"/>
                 <data android:scheme="http"/>

--- a/application/vlc-android/src/org/videolan/vlc/gui/dialogs/NetworkServerDialog.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/dialogs/NetworkServerDialog.kt
@@ -171,6 +171,7 @@ class NetworkServerDialog : VLCBottomSheetDialogFragment(), AdapterView.OnItemSe
         return when (protocols[position]) {
             "FTP" -> FTP_DEFAULT_PORT
             "FTPS" -> FTPS_DEFAULT_PORT
+            "FTPES" -> FTPES_DEFAULT_PORT
             "SFTP" -> SFTP_DEFAULT_PORT
             "HTTP" -> HTTP_DEFAULT_PORT
             "HTTPS" -> HTTPS_DEFAULT_PORT
@@ -249,6 +250,7 @@ class NetworkServerDialog : VLCBottomSheetDialogFragment(), AdapterView.OnItemSe
 
         const val FTP_DEFAULT_PORT = "21"
         const val FTPS_DEFAULT_PORT = "990"
+        const val FTPES_DEFAULT_PORT = "21"
         const val SFTP_DEFAULT_PORT = "22"
         const val HTTP_DEFAULT_PORT = "80"
         const val HTTPS_DEFAULT_PORT = "443"

--- a/application/vlc-android/src/org/videolan/vlc/repository/BrowserFavRepository.kt
+++ b/application/vlc-android/src/org/videolan/vlc/repository/BrowserFavRepository.kt
@@ -86,7 +86,7 @@ class BrowserFavRepository(private val browserFavDao: BrowserFavDao) {
             isEmpty() -> this
             !networkMonitor.connected -> emptyList()
             !NetworkMonitor.getInstance(AppContextProvider.appContext).lanAllowed -> {
-                val schemes = Arrays.asList("ftp", "sftp", "ftps", "http", "https")
+                val schemes = Arrays.asList("ftp", "sftp", "ftps", "ftpes", "http", "https")
                 mutableListOf<MediaWrapper>().apply { this@filterNetworkFavs.filterTo(this) { schemes.contains(it.uri.scheme) } }
             }
             else -> this

--- a/application/vlc-android/src/org/videolan/vlc/util/Browserutils.kt
+++ b/application/vlc-android/src/org/videolan/vlc/util/Browserutils.kt
@@ -39,15 +39,15 @@ fun isSchemeStreaming(scheme: String?): Boolean = when {
 fun isSchemeHttpOrHttps(scheme: String?): Boolean = scheme?.startsWith("http") == true
 
 fun isSchemeSupported(scheme: String?) = when(scheme) {
-    "file", "smb", "ssh", "nfs", "ftp", "ftps", "content" -> true
+    "file", "smb", "ssh", "nfs", "ftp", "ftps", "ftpes", "content" -> true
     else -> false
 }
 fun String?.isSchemeNetwork() = when(this) {
-    "smb", "ssh", "nfs", "ftp", "ftps", "upnp" -> true
+    "smb", "ssh", "nfs", "ftp", "ftps", "ftpes", "upnp" -> true
     else -> false
 }
 
-fun String?.isSchemeFavoriteEditable() = this in arrayOf("ftp", "ftps", "sftp", "smb", "nfs")
+fun String?.isSchemeFavoriteEditable() = this in arrayOf("ftp", "ftps", "ftpes", "sftp", "smb", "nfs")
 
 fun String?.isSchemeFile() = when(this) {
     "file", null -> true

--- a/application/vlc-android/src/org/videolan/vlc/util/FileUtils.kt
+++ b/application/vlc-android/src/org/videolan/vlc/util/FileUtils.kt
@@ -294,7 +294,7 @@ object FileUtils {
     fun canSave(mw: MediaWrapper?): Boolean {
         if (mw == null || mw.uri == null) return false
         val scheme = mw.uri.scheme
-        return scheme in arrayOf("file", "smb", "nfs", "ftp", "ftps", "sftp", "upnp")
+        return scheme in arrayOf("file", "smb", "nfs", "ftp", "ftps", "ftpes", "sftp", "upnp")
     }
 
     @WorkerThread


### PR DESCRIPTION
Some servers like Synology may support only FTP/FTPES/SFTP, but not FTPS, so it was impossible to connect via FTPES using mobile device/Android TV. (FTPES is slightly faster than SFTP)

In desktop VLC you may enter the protocol manually, but in the mobile app it can only be picked from the preset list.

This PR just enables the existing VLC support for FTPES by adding it to the supported server protocol list.
![image](https://github.com/videolan/vlc-android/assets/6125027/1410d707-1b51-47dd-9adb-52ed8192eb3e)
