### PR TITLE
Add fast play speed SeekBar and migration

### DIFF
--- a/application/resources/src/main/res/values/arrays.xml
+++ b/application/resources/src/main/res/values/arrays.xml
@@ -642,22 +642,6 @@
         <item>2</item>
     </string-array>
 
-    <string-array name="fastplay_speed_entries">
-        <item>1.25x</item>
-        <item>1.5x</item>
-        <item>2x</item>
-        <item>4x</item>
-        <item>8x</item>
-    </string-array>
-
-    <string-array name="fastplay_speed_values">
-        <item>1.25</item>
-        <item>1.5</item>
-        <item>2</item>
-        <item>4</item>
-        <item>8</item>
-    </string-array>
-
     <string-array name="widget_themes_entries" translatable="false">
         <item>@string/material_you</item>
         <item>@string/palette</item>

--- a/application/resources/src/main/res/values/strings.xml
+++ b/application/resources/src/main/res/values/strings.xml
@@ -420,6 +420,7 @@
     <string name="enable_tap_and_hold_fastplay_title">Enable Fastplay</string>
     <string name="enable_tap_and_hold_fastplay_summary">Tap and hold to increase the playback speed</string>
     <string name="fastplay_speed_title">Fastplay speed</string>
+    <string name="fastplay_speed_summary">%sx</string>
     <string name="fastplay_title">Playing at %sx</string>
     <string name="fastplay_subtitle">Release to stop</string>
     <string name="show_bookmark_buttons">Show bookmark buttons</string>

--- a/application/tools/src/main/java/org/videolan/tools/Settings.kt
+++ b/application/tools/src/main/java/org/videolan/tools/Settings.kt
@@ -62,7 +62,7 @@ object Settings : SingletonHolder<SharedPreferences, Context>({ init(it.applicat
         incognitoMode = prefs.getBoolean(KEY_INCOGNITO, false)
         safeMode = prefs.getBoolean(KEY_SAFE_MODE, false) && prefs.getString(KEY_SAFE_MODE_PIN, "")?.isNotBlank() == true
         remoteAccessEnabled.postValue(prefs.getBoolean(KEY_ENABLE_REMOTE_ACCESS, false))
-        fastplaySpeed = prefs.getString(FASTPLAY_SPEED, "2")?.toFloat() ?: 2f
+        fastplaySpeed = prefs.getInt(FASTPLAY_SPEED, 8) * 0.25f
         return prefs
     }
 

--- a/application/vlc-android/res/xml/preferences_video_controls.xml
+++ b/application/vlc-android/res/xml/preferences_video_controls.xml
@@ -105,16 +105,18 @@
                 android:title="@string/enable_tap_and_hold_fastplay_title"
                 app:iconSpaceReserved="false"
                 app:singleLineTitle="false" />
-        <ListPreference
-                android:defaultValue="2"
+        <SeekBarPreference
+                android:defaultValue="8"
                 android:dependency="enable_fastplay"
-                android:entries="@array/fastplay_speed_entries"
-                android:entryValues="@array/fastplay_speed_values"
                 android:key="fastplay_speed"
+                android:max="32"
                 android:summary="%s"
                 android:title="@string/fastplay_speed_title"
                 app:iconSpaceReserved="false"
-                app:singleLineTitle="false" />
+                app:min="5"
+                app:seekBarIncrement="1"
+                app:singleLineTitle="false"
+                app:updatesContinuously="true" />
 
     </PreferenceCategory>
 

--- a/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesVideoControls.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesVideoControls.kt
@@ -49,6 +49,7 @@ import org.videolan.tools.SCREENSHOT_MODE
 import org.videolan.tools.Settings
 import org.videolan.tools.VIDEO_HUD_TIMEOUT
 import org.videolan.tools.coerceInOrDefault
+import org.videolan.tools.readableString
 import org.videolan.vlc.R
 import org.videolan.vlc.gui.video.VideoPlayerActivity
 
@@ -78,6 +79,7 @@ class PreferencesVideoControls : BasePreferenceFragment(), SharedPreferences.OnS
         findPreference<Preference>(LOCK_USE_SENSOR)?.isVisible = !AndroidDevices.isAndroidTv
 
         updateHudTimeoutSummary()
+        updateFastplaySpeedSummary()
         val audiomanager = requireActivity().getSystemService<AudioManager>()!!
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || audiomanager.isVolumeFixed) {
             audioBoostPref?.isChecked = false
@@ -95,6 +97,10 @@ class PreferencesVideoControls : BasePreferenceFragment(), SharedPreferences.OnS
             -1 -> findPreference<Preference>(VIDEO_HUD_TIMEOUT)?.summary = getString(R.string.timeout_infinite)
             else -> findPreference<Preference>(VIDEO_HUD_TIMEOUT)?.summary =  getString(R.string.video_hud_timeout_summary, Settings.videoHudDelay.toString())
         }
+    }
+
+    private fun updateFastplaySpeedSummary() {
+        findPreference<Preference>(FASTPLAY_SPEED)?.summary = getString(R.string.fastplay_speed_summary, Settings.fastplaySpeed.readableString())
     }
 
     override fun onStart() {
@@ -126,7 +132,8 @@ class PreferencesVideoControls : BasePreferenceFragment(), SharedPreferences.OnS
                 Settings.videoDoubleTapJumpDelay = sharedPreferences.getInt(KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY, 20)
             }
             FASTPLAY_SPEED -> {
-                Settings.fastplaySpeed = sharedPreferences.getString(FASTPLAY_SPEED, "2")?.toFloat() ?: 2f
+                Settings.fastplaySpeed = sharedPreferences.getInt(FASTPLAY_SPEED, 8) * 0.25f
+                updateFastplaySpeedSummary()
             }
         }
     }

--- a/application/vlc-android/src/org/videolan/vlc/util/VersionMigration.kt
+++ b/application/vlc-android/src/org/videolan/vlc/util/VersionMigration.kt
@@ -59,7 +59,7 @@ import org.videolan.vlc.isVLC4
 import java.io.File
 import java.io.IOException
 
-private const val CURRENT_VERSION = 15
+private const val CURRENT_VERSION = 16
 
 object VersionMigration {
 
@@ -124,6 +124,10 @@ object VersionMigration {
 
         if (lastVersion < 15) {
             migrateToVersion15(settings)
+        }
+
+        if (lastVersion < 16) {
+            migrateToVersion16(settings)
         }
 
         //Major version upgrade
@@ -388,6 +392,24 @@ object VersionMigration {
                 settings.edit(true) {
                     putString(DefaultPlaybackActionMediaType.TRACK.defaultActionKey, DefaultPlaybackAction.PLAY_ALL.name)
                 }
+            }
+        }
+    }
+
+    /**
+     * Migrate the fast play speed setting
+     *
+     */
+    private fun migrateToVersion16(settings: SharedPreferences) {
+        Log.i(this::class.java.simpleName, "Migrate to version 16: Migrate the fast play speed setting")
+        if (settings.contains("fastplay_speed")) {
+            settings.edit(true) {
+                putInt("fastplay_speed", settings.getString("fastplay_speed", "2")
+                    ?.toFloat()
+                    ?.div(0.25f)
+                    ?.toInt()
+                    ?.coerceInOrDefault(5, 32, 8)
+                    ?: 8)
             }
         }
     }


### PR DESCRIPTION
This pull request replaces the fast play speed `ListPreference` with `SeekBarPreference`, enabling fine-grained control over the value, ranging from 1.25x to 8x in 0.25x increments.

To address the integer-only limitation of `SeekBarPreference`, `fastplay_speed` now stores the multiplier of 0.25x. Corresponding migration code is included in this pull request.

I tried creating this PR at code.videolan.org however my newly created account is currently still pending for approval.