### PR TITLE
[FEATURE] Add one-tap "Repeat Timer" option to the sleep timer expiry dialog

### DIFF
--- a/application/resources/src/main/res/values-zh-rCN/strings.xml
+++ b/application/resources/src/main/res/values-zh-rCN/strings.xml
@@ -281,6 +281,7 @@
     <string name="show_playlist">显示播放列表</string>
     <string name="hide_playlist">隐藏播放列表</string>
     <string name="hold_to_stop">按住可停止</string>
+    <string name="reset_sleep_timer_message">计时时间已到</string>
 
     <!-- About -->
     <string name="app_name_full">VLC for Android</string>

--- a/application/resources/src/main/res/values-zh-rTW/strings.xml
+++ b/application/resources/src/main/res/values-zh-rTW/strings.xml
@@ -300,6 +300,7 @@
     <string name="show_playlist">顯示播放清單</string>
     <string name="hide_playlist">隱藏播放清單</string>
     <string name="hold_to_stop">按住以停止</string>
+    <string name="reset_sleep_timer_message">計時時間已到</string>
 
     <!-- About -->
     <string name="app_name_full">VLC for Android</string>

--- a/application/resources/src/main/res/values/strings.xml
+++ b/application/resources/src/main/res/values/strings.xml
@@ -318,6 +318,7 @@
     <string name="show_playlist">Show playlist</string>
     <string name="hide_playlist">Hide playlist</string>
     <string name="hold_to_stop">Hold to stop</string>
+    <string name="reset_sleep_timer_message">Time\'s up</string>
 
     <!-- About -->
     <string name="app_name_full">VLC for Android</string>

--- a/application/vlc-android/res/layout/dialog_reset_sleep_timer.xml
+++ b/application/vlc-android/res/layout/dialog_reset_sleep_timer.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        >
+
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/reset_sleep_timer_message"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="@string/close"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <Button
+            android:id="@+id/reset_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/reset"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/close_button"
+            app:layout_constraintTop_toBottomOf="@+id/message"
+            app:layout_constraintVertical_bias="0.0" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/application/vlc-android/src/org/videolan/vlc/PlaybackService.kt
+++ b/application/vlc-android/src/org/videolan/vlc/PlaybackService.kt
@@ -164,6 +164,7 @@ import org.videolan.tools.getResourceUri
 import org.videolan.tools.markBidi
 import org.videolan.tools.readableSize
 import org.videolan.vlc.gui.AudioPlayerContainerActivity
+import org.videolan.vlc.gui.DialogActivity
 import org.videolan.vlc.gui.dialogs.VideoTracksDialog
 import org.videolan.vlc.gui.dialogs.adapters.VlcTrack
 import org.videolan.vlc.gui.helpers.AudioUtil
@@ -1989,7 +1990,10 @@ class PlaybackService : MediaBrowserServiceCompat(), LifecycleOwner, CoroutineSc
                     val timerExpired = System.currentTimeMillis() > it.timeInMillis
                     val shouldStop = if (waitForMediaEnd) timerExpired && mediaEndReached else timerExpired
                     if (shouldStop) {
-                        withContext(Dispatchers.Main) { if (isPlaying) stop() else setSleepTimer(null) }
+                        withContext(Dispatchers.Main) { if (isPlaying) {
+                            pause()
+                            startResetTimerDialog()
+                        } else setSleepTimer(null) }
                     }
                 }
                 if (mediaEndReached) mediaEndReached = false
@@ -1997,6 +2001,13 @@ class PlaybackService : MediaBrowserServiceCompat(), LifecycleOwner, CoroutineSc
             }
         }
     }
+
+    private fun startResetTimerDialog() {
+        val intent = Intent(DialogActivity.KEY_SLEEP_TIMEUP,null,this, DialogActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(intent)
+    }
+
 
     private fun stopSleepTimerJob() {
         if (BuildConfig.DEBUG) Log.d("SleepTimer", "stopSleepTimerJob")

--- a/application/vlc-android/src/org/videolan/vlc/gui/DialogActivity.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/DialogActivity.kt
@@ -33,6 +33,7 @@ import org.videolan.resources.util.parcelableList
 import org.videolan.vlc.R
 import org.videolan.vlc.gui.dialogs.DeviceDialog
 import org.videolan.vlc.gui.dialogs.NetworkServerDialog
+import org.videolan.vlc.gui.dialogs.ResetSleepTimerDialog
 import org.videolan.vlc.media.MediaUtils
 import org.videolan.vlc.util.showVlcDialog
 
@@ -52,6 +53,7 @@ class DialogActivity : BaseActivity() {
             KEY_SERVER -> setupServerDialog()
             KEY_SUBS_DL -> setupSubsDialog()
             KEY_DEVICE -> setupDeviceDialog()
+            KEY_SLEEP_TIMEUP -> setupResetSleepTimerDialog()
             KEY_DIALOG -> {
                 dialog?.run {
                     showVlcDialog(this)
@@ -61,6 +63,12 @@ class DialogActivity : BaseActivity() {
             }
             else -> finish()
         }
+    }
+
+    private fun setupResetSleepTimerDialog() {
+        setTheme(R.style.Theme_VLC)
+        val dialog = ResetSleepTimerDialog.newInstance()
+        dialog.show(supportFragmentManager, ResetSleepTimerDialog::class.java.simpleName)
     }
 
     private fun setupDeviceDialog() {
@@ -109,6 +117,7 @@ class DialogActivity : BaseActivity() {
         const val KEY_SUBS_DL = "subsdlDialog"
         const val KEY_DEVICE = "deviceDialog"
         const val KEY_DIALOG = "vlcDialog"
+        const val KEY_SLEEP_TIMEUP = "sleepTimeUp"
 
         const val EXTRA_MEDIA = "extra_media"
         const val EXTRA_PATH = "extra_path"

--- a/application/vlc-android/src/org/videolan/vlc/gui/dialogs/ResetSleepTimerDialog.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/dialogs/ResetSleepTimerDialog.kt
@@ -1,0 +1,78 @@
+/**
+ * **************************************************************************
+ * ResetSleepTimerDialog.kt
+ * ****************************************************************************
+ * Copyright © 2015 VLC authors and VideoLAN
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ * ***************************************************************************
+ */
+package org.videolan.vlc.gui.dialogs
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
+import org.videolan.vlc.databinding.DialogResetSleepTimerBinding
+import org.videolan.vlc.viewmodels.PlaylistModel
+import java.util.Calendar
+
+
+class ResetSleepTimerDialog : VLCBottomSheetDialogFragment() {
+
+    lateinit var binding: DialogResetSleepTimerBinding
+    private val playlistModel by lazy { PlaylistModel.get(this) }
+    companion object {
+        fun newInstance(): ResetSleepTimerDialog {
+            return ResetSleepTimerDialog()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun getDefaultState(): Int {
+       return STATE_EXPANDED
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = DialogResetSleepTimerBinding.inflate(inflater,container,false)
+        binding.resetButton.setOnClickListener {
+            val sleepTime = Calendar.getInstance()
+            sleepTime.timeInMillis += playlistModel.service?.sleepTimerInterval?:0L
+            sleepTime.set(Calendar.SECOND, 0)
+            playlistModel.service?.setSleepTimer(sleepTime)
+            playlistModel.service?.play()
+            dismiss()
+            activity?.finish()
+        }
+        binding.closeButton.setOnClickListener {
+            playlistModel.service?.stop()
+            dismiss()
+            activity?.finish()
+        }
+        return binding.root
+    }
+
+    override fun needToManageOrientation(): Boolean {
+        return true
+    }
+
+    override fun initialFocusedView(): View {
+        return binding.message
+    }
+}


### PR DESCRIPTION
This PR introduces a quality-of-life improvement for the sleep timer feature, addressing a common user experience issue when the timer expires.


The Problem:
Currently, when the sleep timer expires, playback simply stops. If the user hasn't fallen asleep yet, they must fully wake up, unlock the device, navigate back to the player, open the menu, and manually set the sleep timer all over again. This process is cumbersome and disruptive, especially in a dark or low-light environment when trying to sleep.


The Solution:
This PR adds an intuitive "Repeat Timer" option to the expiration dialog. When the sleep timer ends, the new system-level dialog not only notifies the user but also presents a clear choice:
"Repeat": Instantly restarts the sleep timer with the previously used duration (e.g., 30 minutes). This is a one-tap action.
"Close": Stops playback as before.
This creates a seamless loop for the user until they finally fall asleep, eliminating unnecessary friction.


Screen Recordings:
https://github.com/user-attachments/assets/894b9f22-af77-4f68-9de0-9db474081bb8


Key Implementation Details:
The new dialog is implemented using a transparent Activity. This ensures it is visible and actionable from any screen (player, playlist, etc.) , without requiring special permissions.


Resolves:
This enhancement significantly improves the usability of the sleep timer for its core use case. It addresses the implicit need for a quicker, less disruptive way to extend playback when trying to fall asleep.