### PR TITLE
Refresh dependencies for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On Debian/Ubuntu, install the required dependencies:
 ```bash
 sudo apt install automake ant autopoint cmake build-essential libtool-bin \
     patch pkg-config protobuf-compiler ragel subversion unzip git \
-    openjdk-8-jre openjdk-8-jdk flex python wget
+    default-jre default-jdk flex python3 wget gettext
 ```
 
 Setup the build environment:


### PR DESCRIPTION
Refresh dependencies for Debian/Ubuntu

```
root@debian:~# cat /etc/debian_version
13.4
root@debian:~# sudo apt install automake ant autopoint cmake build-essential libtool-bin \
    patch pkg-config protobuf-compiler ragel subversion unzip git \
    openjdk-8-jre openjdk-8-jdk flex python wget
Package python is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python-is-python3


Error: Unable to locate package openjdk-8-jre
Error: Unable to locate package openjdk-8-jdk
Error: Package 'python' has no installation candidate
```

The PR:
Replaces python with python3
Replaces openjdk-8-jre and openjdk-8-jdk which are not present (unless including unstable sources) with default-jre default-jdk (pointing to openjdk-21-jre and openjdk-21-jdk) as of today.
Add gettext dependency, otherwise the LibVLC Android compilation fails with the error :

```
configure.ac:130: error: possibly undefined macro: AM_ICONV
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /usr/bin/autoconf failed with exit status: 1
```
