### PR TITLE
Allow to jump within current media with prev/next headset buttons

### DIFF
--- a/application/resources/src/main/res/values-en-rGB/strings.xml
+++ b/application/resources/src/main/res/values-en-rGB/strings.xml
@@ -1299,6 +1299,8 @@
     <string name="show_only_favs">Show only favourites</string>
     <string name="ignore_headset_media_button_presses">Ignore headset media button presses</string>
     <string name="ignore_headset_media_button_presses_summary">Useful, for instance, if you are using a headset with broken physical buttons</string>
+    <string name="headset_jump_on_previous_next">Jump on previous/next</string>
+    <string name="headset_jump_on_previous_next_summary">When previous/next is pressed, jump back/forward in the current media by the time specified in "Double tap time delay"</string>
     <string name="replace_playlist">Replace playlist</string>
 
     <!-- Remote access -->

--- a/application/resources/src/main/res/values/strings.xml
+++ b/application/resources/src/main/res/values/strings.xml
@@ -1318,6 +1318,8 @@
     <string name="show_only_favs">Show only favorites</string>
     <string name="ignore_headset_media_button_presses">Ignore headset media button presses</string>
     <string name="ignore_headset_media_button_presses_summary">Useful, for instance, if you are using a headset with broken physical buttons</string>
+    <string name="headset_jump_on_previous_next">Jump on previous/next</string>
+    <string name="headset_jump_on_previous_next_summary">When previous/next is pressed, jump back/forward in the current media by the time specified in "Double tap time delay"</string>
     <string name="replace_playlist">Replace playlist</string>
 
     <!-- Remote access -->

--- a/application/tools/src/main/java/org/videolan/tools/Settings.kt
+++ b/application/tools/src/main/java/org/videolan/tools/Settings.kt
@@ -28,6 +28,7 @@ object Settings : SingletonHolder<SharedPreferences, Context>({ init(it.applicat
     var videoDoubleTapJumpDelay = 10
     var audioJumpDelay = 10
     var audioLongJumpDelay = 20
+    var headsetJumpOnPreviousNext = false
     var audioShowTrackNumbers = MutableLiveData(false)
     var showHiddenFiles = false
     var showTrackNumber = true
@@ -55,6 +56,7 @@ object Settings : SingletonHolder<SharedPreferences, Context>({ init(it.applicat
         videoDoubleTapJumpDelay = prefs.getInt(KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY, 10)
         audioJumpDelay = prefs.getInt(KEY_AUDIO_JUMP_DELAY, 10)
         audioLongJumpDelay = prefs.getInt(KEY_AUDIO_LONG_JUMP_DELAY, 20)
+        headsetJumpOnPreviousNext = prefs.getBoolean(KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT, false)
         audioShowTrackNumbers.postValue(prefs.getBoolean(KEY_AUDIO_SHOW_TRACK_NUMBERS, false))
         showHiddenFiles = prefs.getBoolean(BROWSER_SHOW_HIDDEN_FILES, !tvUI)
         showTrackNumber = prefs.getBoolean(ALBUMS_SHOW_TRACK_NUMBER, true)
@@ -160,6 +162,7 @@ const val KEY_VIDEO_LONG_JUMP_DELAY = "video_long_jump_delay"
 const val KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY = "video_double_tap_jump_delay"
 const val KEY_AUDIO_JUMP_DELAY = "audio_jump_delay"
 const val KEY_AUDIO_LONG_JUMP_DELAY = "audio_long_jump_delay"
+const val KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT = "headset_jump_on_previous_next"
 const val KEY_AUDIO_FORCE_SHUFFLE = "audio_force_shuffle"
 const val KEY_AUDIO_SHOW_TRACK_NUMBERS = "audio_show_track_numbers"
 const val KEY_AUDIO_SHOW_CHAPTER_BUTTONS = "audio_show_chapter_buttons"
@@ -246,6 +249,8 @@ const val HINGE_ON_RIGHT = "hinge_on_right"
 const val AUDIO_HINGE_ON_RIGHT = "audio_hinge_on_right"
 const val TV_FOLDERS_FIRST = "tv_folders_first"
 const val KEY_OBSOLETE_RESTORE_FILE_WARNED = "obsolete_restore_file_warned"
+
+const val JUMP_INSTEAD_OF_MEDIA_CHANGE = "jump_instead_of_media_change"
 
 const val VIDEO_PAUSED = "VideoPaused"
 const val VIDEO_SPEED = "VideoSpeed"

--- a/application/vlc-android/res/xml/preferences_audio_controls.xml
+++ b/application/vlc-android/res/xml/preferences_audio_controls.xml
@@ -29,6 +29,17 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/headset_prefs_category"
+            app:iconSpaceReserved="false">
+
+        <CheckBoxPreference
+                app:singleLineTitle="false"
+                android:defaultValue="false"
+                android:key="headset_jump_on_previous_next"
+                android:title="@string/headset_jump_on_previous_next"
+                android:summary="@string/headset_jump_on_previous_next_summary"/>
+    </PreferenceCategory>
+
 
     <PreferenceCategory android:title="@string/interface_prefs_screen"
             app:iconSpaceReserved="false">

--- a/application/vlc-android/res/xml/preferences_video_controls.xml
+++ b/application/vlc-android/res/xml/preferences_video_controls.xml
@@ -120,6 +120,17 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/headset_prefs_category"
+            app:iconSpaceReserved="false">
+
+        <CheckBoxPreference
+                app:singleLineTitle="false"
+                android:defaultValue="false"
+                android:key="headset_jump_on_previous_next"
+                android:title="@string/headset_jump_on_previous_next"
+                android:summary="@string/headset_jump_on_previous_next_summary"/>
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/player_controls"
             app:iconSpaceReserved="false">
         <CheckBoxPreference

--- a/application/vlc-android/src/org/videolan/vlc/MediaSessionCallback.kt
+++ b/application/vlc-android/src/org/videolan/vlc/MediaSessionCallback.kt
@@ -111,6 +111,32 @@ internal class MediaSessionCallback(private val playbackService: PlaybackService
                 true
             } else false
         }
+
+        if (Settings.headsetJumpOnPreviousNext && (keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PREVIOUS || keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_NEXT)) {
+            if(keyEvent.action == KeyEvent.ACTION_DOWN) {
+                when (keyEvent.keyCode) {
+                    KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+                        seek(
+                            (playbackService.getTime() - Settings.videoDoubleTapJumpDelay * ONE_SECOND).coerceAtLeast(
+                                0
+                            )
+                        );
+                        checkForSeekFailure(forward = false);
+                    }
+
+                    KeyEvent.KEYCODE_MEDIA_NEXT -> {
+                        seek(
+                            (playbackService.getTime() + Settings.videoDoubleTapJumpDelay * ONE_SECOND).coerceAtMost(
+                                playbackService.length
+                            )
+                        );
+                        checkForSeekFailure(forward = true);
+                    }
+                }
+            }
+            return true
+        }
+
         /**
          * Implement fast forward and rewind behavior by directly handling the previous and next button events.
          * Normally the buttons are triggered on ACTION_DOWN; however, we ignore the ACTION_DOWN event when

--- a/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesAudioControls.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesAudioControls.kt
@@ -29,6 +29,7 @@ import org.videolan.tools.KEY_AUDIO_JUMP_DELAY
 import org.videolan.tools.KEY_AUDIO_LONG_JUMP_DELAY
 import org.videolan.tools.KEY_AUDIO_SHOW_BOOkMARK_BUTTONS
 import org.videolan.tools.KEY_AUDIO_SHOW_TRACK_NUMBERS
+import org.videolan.tools.KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT
 import org.videolan.tools.Settings
 import org.videolan.vlc.R
 import org.videolan.vlc.gui.video.VideoPlayerActivity
@@ -74,6 +75,9 @@ class PreferencesAudioControls : BasePreferenceFragment(), SharedPreferences.OnS
                 if (!sharedPreferences.getBoolean(KEY_AUDIO_SHOW_BOOkMARK_BUTTONS, true)) {
                     bookmarkMarkersPreference.isChecked = false
                 }
+            }
+            KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT -> {
+                Settings.headsetJumpOnPreviousNext = sharedPreferences.getBoolean(KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT, false)
             }
         }
         Settings.onAudioControlsChanged()

--- a/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesVideoControls.kt
+++ b/application/vlc-android/src/org/videolan/vlc/gui/preferences/PreferencesVideoControls.kt
@@ -40,6 +40,7 @@ import org.videolan.tools.ENABLE_SWIPE_SEEK
 import org.videolan.tools.ENABLE_VOLUME_GESTURE
 import org.videolan.tools.FASTPLAY_SPEED
 import org.videolan.tools.KEY_AUDIO_BOOST
+import org.videolan.tools.KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT
 import org.videolan.tools.KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY
 import org.videolan.tools.KEY_VIDEO_JUMP_DELAY
 import org.videolan.tools.KEY_VIDEO_LONG_JUMP_DELAY
@@ -130,6 +131,9 @@ class PreferencesVideoControls : BasePreferenceFragment(), SharedPreferences.OnS
             }
             KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY -> {
                 Settings.videoDoubleTapJumpDelay = sharedPreferences.getInt(KEY_VIDEO_DOUBLE_TAP_JUMP_DELAY, 20)
+            }
+            KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT -> {
+                Settings.headsetJumpOnPreviousNext = sharedPreferences.getBoolean(KEY_HEADSET_JUMP_ON_PREVIOUS_NEXT, false)
             }
             FASTPLAY_SPEED -> {
                 Settings.fastplaySpeed = sharedPreferences.getInt(FASTPLAY_SPEED, 20) / 10f


### PR DESCRIPTION
This makes the "double-tap" gesture available from the headset. This is particularly useful in long medias like podcasts or movies, to:
- jump back X seconds after a distraction
- skip advertisement, opening credits...

The feature is off by default. To enable it, there is a new setting in the "Control settings". Since none of the existing categories fitted, a new one called "Headset" is introduced, for both audio and video medias.

The time to jump is configurable too but does not required a new setting, it is the same as the one for double-tap ("Double tap time delay").